### PR TITLE
Add admin user command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ migrations:
 	pipenv run python manage.py migrate
 
 
+admin: ## Add an admin user
+admin:
+	pipenv run python manage.py createsuperuser
+
+
 tests: ## Run tests
 tests:
 	pipenv run python manage.py test courses.tests


### PR DESCRIPTION
### Changes in this PR:

- [x] **Add `admin` command to the makefile:** This addition facilitates the justification of the documentation mentioned in the readme file.

   Add an admin user:
  ```
  make admin
  # python manage.py createsuperuser
  ```