### PR TITLE
Fix dashboard project completion rate and difficulty ranking

### DIFF
--- a/courses/templates/courses/dashboard.html
+++ b/courses/templates/courses/dashboard.html
@@ -190,7 +190,10 @@
       <div class="border-b app-border app-surface-muted px-4 py-3">
         <h2 class="text-base font-semibold app-heading">Assignment difficulty</h2>
         <p class="mt-1 text-sm app-muted">
-          Ranked by lowest median homework score. Lower median scores usually indicate harder assignments.
+          Ranked by lowest median question score relative to the maximum
+          achievable. Normalizing by question count makes homeworks of
+          different lengths comparable; a lower percentage indicates a harder
+          assignment.
         </p>
       </div>
       <div class="overflow-x-auto">
@@ -200,6 +203,7 @@
               <th class="px-3 py-2">Rank</th>
               <th class="px-3 py-2">Homework</th>
               <th class="px-3 py-2 text-right">Median score</th>
+              <th class="px-3 py-2 text-right">Score %</th>
               <th class="px-3 py-2 text-right">Completion</th>
             </tr>
           </thead>
@@ -208,7 +212,8 @@
               <tr>
                 <td class="px-3 py-2 font-semibold app-heading">{{ hw_stat.difficulty_rank }}</td>
                 <td class="min-w-48 px-3 py-2 font-medium app-heading">{{ hw_stat.homework.title }}</td>
-                <td class="px-3 py-2 text-right">{{ hw_stat.score_median|floatformat:0 }}</td>
+                <td class="px-3 py-2 text-right">{{ hw_stat.questions_score_median|floatformat:0 }} / {{ hw_stat.max_questions_score }}</td>
+                <td class="px-3 py-2 text-right">{{ hw_stat.score_ratio_pct }}%</td>
                 <td class="px-3 py-2 text-right">{{ hw_stat.completion_rate }}%</td>
               </tr>
             {% endfor %}

--- a/courses/tests/test_dashboard.py
+++ b/courses/tests/test_dashboard.py
@@ -10,6 +10,8 @@ from courses.models import (
     Enrollment,
     Homework,
     HomeworkState,
+    Question,
+    QuestionTypes,
     Submission,
     Project,
     ProjectState,
@@ -250,8 +252,30 @@ class DashboardHomeworkStatsTestCase(TestCase):
         self.assertIsNone(hw_stat["time_lecture_q75"])
         self.assertEqual(hw_stat["completion_rate"], 40.0)
 
+    def _add_questions(self, homework, count):
+        """Create `count` 1-point questions for a homework."""
+        Question.objects.bulk_create(
+            [
+                Question(
+                    homework=homework,
+                    text=f"Q{i}",
+                    question_type=QuestionTypes.MULTIPLE_CHOICE.value,
+                    scores_for_correct_answer=1,
+                )
+                for i in range(count)
+            ]
+        )
+
     def test_homework_difficulty_ranking(self):
-        """Test homework difficulty ranking by lowest median score."""
+        """Difficulty is ranked by the question score normalized by question count.
+
+        A short homework with a high raw median is not "harder" than a long
+        homework with a lower per-question score, so ranking must use the ratio
+        of the median question score to the max achievable.
+        """
+        # Short homework: 3 questions, students get all 3 right -> ratio 100%.
+        self._add_questions(self.homework, 3)
+        # Long homework: 10 questions, students get 5 -> ratio 50% (harder).
         harder_homework = Homework.objects.create(
             course=self.course,
             slug="hw2",
@@ -259,17 +283,17 @@ class DashboardHomeworkStatsTestCase(TestCase):
             due_date=timezone.now() + timedelta(days=14),
             state=HomeworkState.OPEN.value,
         )
+        self._add_questions(harder_homework, 10)
 
-        for i, (user, enrollment) in enumerate(
-            zip(self.users, self.enrollments)
-        ):
+        for user, enrollment in zip(self.users, self.enrollments):
             Submission.objects.create(
                 homework=self.homework,
                 student=user,
                 enrollment=enrollment,
                 time_spent_lectures=2.0,
                 time_spent_homework=3.0,
-                total_score=90 + i,
+                questions_score=3,
+                total_score=3,
             )
             Submission.objects.create(
                 homework=harder_homework,
@@ -277,7 +301,10 @@ class DashboardHomeworkStatsTestCase(TestCase):
                 enrollment=enrollment,
                 time_spent_lectures=2.0,
                 time_spent_homework=3.0,
-                total_score=50 + i,
+                questions_score=5,
+                # Bonus points push total_score above the short homework's,
+                # which under the old (raw median) ranking wrongly looked easier.
+                total_score=12,
             )
 
         url = reverse("dashboard", args=[self.course.slug])
@@ -285,11 +312,14 @@ class DashboardHomeworkStatsTestCase(TestCase):
 
         difficulty_stats = response.context["homework_difficulty_stats"]
 
+        # 50% < 100% -> the long homework is correctly ranked hardest.
         self.assertEqual(difficulty_stats[0]["homework"], harder_homework)
         self.assertEqual(difficulty_stats[0]["difficulty_rank"], 1)
-        self.assertEqual(difficulty_stats[0]["score_median"], 52)
+        self.assertEqual(difficulty_stats[0]["score_ratio_pct"], 50.0)
+        self.assertEqual(difficulty_stats[0]["max_questions_score"], 10)
         self.assertEqual(difficulty_stats[1]["homework"], self.homework)
         self.assertEqual(difficulty_stats[1]["difficulty_rank"], 2)
+        self.assertEqual(difficulty_stats[1]["score_ratio_pct"], 100.0)
 
         self.assertContains(response, "Assignment difficulty")
         self.assertContains(response, "Completion")
@@ -486,6 +516,45 @@ class DashboardProjectStatsTestCase(TestCase):
         # Check quartile calculations
         self.assertIsNotNone(response.context["project_score_median"])
         self.assertIsNotNone(response.context["project_time_median"])
+
+    def test_completion_rate_with_multiple_projects(self):
+        """Completion rate counts distinct students, not enrollments x projects."""
+        project2 = Project.objects.create(
+            course=self.course,
+            slug="project2",
+            title="Project 2",
+            submission_due_date=timezone.now() + timedelta(days=7),
+            peer_review_due_date=timezone.now() + timedelta(days=14),
+            state=ProjectState.COMPLETED.value,
+        )
+
+        # 3 distinct students submit project 1; 2 of them also submit project 2,
+        # for 5 submissions total across 2 projects.
+        for i in range(3):
+            self.create_project_submission(
+                self.users[i], self.enrollments[i]
+            )
+        for i in range(2):
+            ProjectSubmission.objects.create(
+                project=project2,
+                student=self.users[i],
+                enrollment=self.enrollments[i],
+                github_link="https://github.com/test/repo2",
+                passed=True,
+                total_score=80,
+                time_spent=10.0,
+            )
+
+        url = reverse("dashboard", args=[self.course.slug])
+        response = self.client.get(url)
+
+        # 3 distinct enrollments submitted out of 6 -> 50%, regardless of the
+        # 2 projects or the 5 total submissions (old formula gave 5/(6*2)=41.7%).
+        self.assertAlmostEqual(
+            response.context["project_completion_rate"],
+            (3 / 6) * 100,
+            places=1,
+        )
 
     def test_project_statistics_with_no_submissions(self):
         """Test project statistics when no submissions exist"""

--- a/courses/views/course.py
+++ b/courses/views/course.py
@@ -13,7 +13,7 @@ from django.contrib import messages
 from django.shortcuts import render, get_object_or_404, redirect
 from django.urls import reverse
 
-from django.db.models import Prefetch, Value, Count, Q
+from django.db.models import Prefetch, Value, Count, Q, Sum
 from django.db.models import Case, When, IntegerField
 from django.db.models.functions import Coalesce
 
@@ -1026,24 +1026,22 @@ def dashboard_view(request, course_slug: str):
     project_submissions = (
         ProjectSubmission.objects.filter(project__course=course)
         .select_related("project", "enrollment")
-        .values("time_spent", "total_score", "passed")
+        .values("enrollment_id", "time_spent", "total_score", "passed")
     )
 
     # Convert to list once for processing
     project_submissions_list = list(project_submissions)
 
-    # Calculate project completion
-    total_projects = Project.objects.filter(course=course).count()
-    total_possible_project_submissions = (
-        total_enrollments * total_projects
-    )
+    # Calculate project completion: the share of enrolled students who
+    # submitted at least one project. Counting distinct enrollments keeps
+    # the rate <= 100% when a course has multiple projects (a student who
+    # submits several projects must not be counted more than once).
+    enrollments_with_submission = {
+        s["enrollment_id"] for s in project_submissions_list
+    }
     project_completion_rate = (
-        (
-            len(project_submissions_list)
-            / total_possible_project_submissions
-            * 100
-        )
-        if total_possible_project_submissions > 0
+        len(enrollments_with_submission) / total_enrollments * 100
+        if total_enrollments > 0
         else 0
     )
 
@@ -1093,8 +1091,13 @@ def dashboard_view(request, course_slug: str):
         safe_quartiles(project_scores)
     )
 
-    # Get homework data efficiently - fetch all at once
-    homeworks = Homework.objects.filter(course=course).order_by("id")
+    # Get homework data efficiently - fetch all at once. The max achievable
+    # questions score (sum of points across the homework's questions) lets us
+    # normalize difficulty: a homework with fewer questions naturally has a
+    # lower median score without being harder.
+    homeworks = Homework.objects.filter(course=course).order_by("id").annotate(
+        max_questions_score=Sum("question__scores_for_correct_answer")
+    )
 
     # Get all homework submissions in one query
     all_hw_submissions = (
@@ -1104,6 +1107,7 @@ def dashboard_view(request, course_slug: str):
             "homework_id",
             "time_spent_lectures",
             "time_spent_homework",
+            "questions_score",
             "total_score",
         )
     )
@@ -1136,6 +1140,11 @@ def dashboard_view(request, course_slug: str):
             for s in hw_submissions
             if s["total_score"] is not None
         ]
+        hw_questions_scores = [
+            s["questions_score"]
+            for s in hw_submissions
+            if s["questions_score"] is not None
+        ]
 
         # Calculate total time (lecture + homework) for each submission
         hw_time_total = []
@@ -1164,6 +1173,18 @@ def dashboard_view(request, course_slug: str):
         )
         hw_score_q25, hw_score_median, hw_score_q75 = safe_quartiles(
             hw_scores
+        )
+
+        # Difficulty is judged on the questions score (excluding bonus points
+        # such as FAQ / learning-in-public) normalized by the max achievable
+        # questions score, so homeworks with different question counts are
+        # comparable. Lower ratio == harder.
+        _, hw_questions_score_median, _ = safe_quartiles(hw_questions_scores)
+        max_questions_score = homework.max_questions_score
+        score_ratio = (
+            hw_questions_score_median / max_questions_score
+            if hw_questions_score_median is not None and max_questions_score
+            else None
         )
 
         homework_stats.append(
@@ -1205,17 +1226,23 @@ def dashboard_view(request, course_slug: str):
                 "score_q25": hw_score_q25,
                 "score_median": hw_score_median,
                 "score_q75": hw_score_q75,
+                "questions_score_median": hw_questions_score_median,
+                "max_questions_score": max_questions_score,
+                "score_ratio": score_ratio,
+                "score_ratio_pct": round(score_ratio * 100, 1)
+                if score_ratio is not None
+                else None,
             }
         )
 
     homework_difficulty_stats = [
         hw_stat
         for hw_stat in homework_stats
-        if hw_stat["score_median"] is not None
+        if hw_stat["score_ratio"] is not None
     ]
     homework_difficulty_stats.sort(
         key=lambda hw_stat: (
-            hw_stat["score_median"],
+            hw_stat["score_ratio"],
             -hw_stat["submissions_count"],
             hw_stat["homework"].title,
         )


### PR DESCRIPTION
## Project completion rate

The rate divided total project submissions by `enrollments * number_of_projects`.
For a course with 3 projects this deflated the figure ~3x (e.g. DE Zoomcamp 2026
showed 7.2% for 686 submissions across 3181 enrollments). The existing test only
had one project, so the bug was invisible.

Now it counts **distinct enrollments with at least one submission** over total
enrollments — the share of enrolled students who submitted a project. This stays
<= 100% even when a student submits multiple projects, and is consistent with how
homework completion rate is computed.

## Assignment difficulty ranking

Ranking used the raw median total score, so a homework with fewer questions
(lower max) looked "harder" than a longer one with a lower per-question score.

Now difficulty is the **median question score normalized by the max achievable
question score** (`Sum(scores_for_correct_answer)`), excluding FAQ /
learning-in-public bonus points. Lower ratio = harder. The table shows
`median / max` and a `Score %` column so the ranking is legible.

## Tests

- `test_completion_rate_with_multiple_projects` — 5 submissions from 3 students
  across 2 projects → 50%, not 41.7%.
- `test_homework_difficulty_ranking` — rewritten: a short 3-question homework
  (100%) vs a long 10-question one (50%, higher raw total) now ranks the long
  one as hardest.

All 21 `courses.tests.test_dashboard` tests pass.
