### PR TITLE
E2E smoke suite for dev (Playwright) + email verification — #194

### DIFF
--- a/.github/workflows/e2e-smoke-dev.yaml
+++ b/.github/workflows/e2e-smoke-dev.yaml
@@ -31,9 +31,15 @@ jobs:
       E2E_API_TOKEN: ${{ secrets.E2E_DEV_API_TOKEN }}
       E2E_ADMIN_EMAIL: ${{ secrets.E2E_DEV_ADMIN_EMAIL }}
       E2E_ADMIN_PASSWORD: ${{ secrets.E2E_DEV_ADMIN_PASSWORD }}
-      # Set once the Datamailer mock inbox (#194 sub-task) is available.
+      # Default email backend: Datamailer mock inbox (#194 mock-inbox sub-task).
+      # Set once it is deployed to dev with MOCK_INBOX_ENABLED=1. URL = the
+      # Datamailer service root; the client appends /api/mock-inbox/...
       E2E_MOCK_INBOX_URL: ${{ secrets.E2E_DEV_MOCK_INBOX_URL }}
       E2E_MOCK_INBOX_API_KEY: ${{ secrets.E2E_DEV_MOCK_INBOX_API_KEY }}
+      # Real SES-inbound backend (#194 issue-194-ses-inbound). Placeholders;
+      # the real-backend email tests xfail until these are provided.
+      E2E_REAL_INBOX_URL: ${{ secrets.E2E_DEV_REAL_INBOX_URL }}
+      E2E_REAL_INBOX_API_KEY: ${{ secrets.E2E_DEV_REAL_INBOX_API_KEY }}
       E2E_EXPECTED_VERSION: ${{ github.event.inputs.expected_version }}
 
     steps:

--- a/.github/workflows/e2e-smoke-dev.yaml
+++ b/.github/workflows/e2e-smoke-dev.yaml
@@ -1,0 +1,78 @@
+name: E2E Smoke (Dev)
+
+# Runs the Playwright e2e smoke suite against dev after each successful dev
+# deploy. See e2e/README.md and issue #194.
+on:
+  # Triggered when "Deploy Dev" finishes.
+  workflow_run:
+    workflows: ["Deploy Dev"]
+    types:
+      - completed
+  # Allow manual runs.
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Target base URL"
+        default: "https://dev.courses.datatalks.club"
+      expected_version:
+        description: "Expected /api/health/ version (optional)"
+        required: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    # For workflow_run, only proceed if the deploy succeeded.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
+    env:
+      E2E_BASE_URL: ${{ github.event.inputs.base_url || 'https://dev.courses.datatalks.club' }}
+      E2E_API_TOKEN: ${{ secrets.E2E_DEV_API_TOKEN }}
+      E2E_ADMIN_EMAIL: ${{ secrets.E2E_DEV_ADMIN_EMAIL }}
+      E2E_ADMIN_PASSWORD: ${{ secrets.E2E_DEV_ADMIN_PASSWORD }}
+      # Set once the Datamailer mock inbox (#194 sub-task) is available.
+      E2E_MOCK_INBOX_URL: ${{ secrets.E2E_DEV_MOCK_INBOX_URL }}
+      E2E_MOCK_INBOX_API_KEY: ${{ secrets.E2E_DEV_MOCK_INBOX_API_KEY }}
+      E2E_EXPECTED_VERSION: ${{ github.event.inputs.expected_version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13.5'
+
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv sync --locked
+
+      - name: Install Playwright browser
+        run: uv run playwright install --with-deps chromium
+
+      - name: Wait for dev health endpoint
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS "${E2E_BASE_URL}/api/health/" | grep -q '"status": *"ok"'; then
+              echo "Dev is healthy."; exit 0
+            fi
+            echo "Waiting for dev health... ($i)"; sleep 10
+          done
+          echo "Dev health never became OK"; exit 1
+
+      - name: Run e2e smoke suite
+        working-directory: e2e
+        run: uv run --project .. pytest -c pytest.ini
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-artifacts
+          path: |
+            e2e/test-results/
+            e2e/playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-smoke-dev.yaml
+++ b/.github/workflows/e2e-smoke-dev.yaml
@@ -1,14 +1,10 @@
 name: E2E Smoke (Dev)
 
-# Runs the Playwright e2e smoke suite against dev after each successful dev
-# deploy. See e2e/README.md and issue #194.
+# Standalone Playwright e2e smoke suite against dev. Runs on demand or on a
+# schedule -- intentionally NOT tied to deploys or commits to main, so it can
+# be triggered independently. See e2e/README.md and issue #194.
 on:
-  # Triggered when "Deploy Dev" finishes.
-  workflow_run:
-    workflows: ["Deploy Dev"]
-    types:
-      - completed
-  # Allow manual runs.
+  # Manual run (the primary way to run this job).
   workflow_dispatch:
     inputs:
       base_url:
@@ -17,14 +13,13 @@ on:
       expected_version:
         description: "Expected /api/health/ version (optional)"
         required: false
+  # Scheduled run, independent of any deploy (daily at 06:00 UTC).
+  schedule:
+    - cron: "0 6 * * *"
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    # For workflow_run, only proceed if the deploy succeeded.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
 
     env:
       E2E_BASE_URL: ${{ github.event.inputs.base_url || 'https://dev.courses.datatalks.club' }}

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -1,0 +1,33 @@
+# e2e smoke-test configuration. Copy to e2e/.env for local runs, or provide
+# these as CI secrets. Never commit real values. The suite also falls back to
+# the repo-root .env for DEV_AUTH_TOKEN / PUBLIC_BASE_URL.
+
+# Target deployment (defaults to dev).
+E2E_BASE_URL=https://dev.courses.datatalks.club
+
+# Staff API token (Authorization: Token <...>). Falls back to DEV_AUTH_TOKEN
+# in the repo-root .env if unset.
+E2E_API_TOKEN=
+
+# Admin login (Django admin form login -- NOT OAuth). Must be a staff account.
+E2E_ADMIN_EMAIL=
+E2E_ADMIN_PASSWORD=
+
+# Test student. If unset, a per-run student
+#   <namespace>@inbox.dtcdev.click
+# is created admin-side and impersonated via django-loginas.
+E2E_STUDENT_EMAIL=
+E2E_STUDENT_PASSWORD=
+
+# Datamailer mock inbox (sub-task of #194). Leave unset until it exists;
+# email-verification tests xfail when unset.
+E2E_MOCK_INBOX_URL=
+E2E_MOCK_INBOX_API_KEY=
+
+# Optional: assert the deployed version matches the just-deployed build.
+E2E_EXPECTED_VERSION=
+
+# Tuning.
+E2E_HEADLESS=1
+E2E_REQUEST_TIMEOUT=30
+E2E_UI_TIMEOUT_MS=20000

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -13,16 +13,27 @@ E2E_API_TOKEN=
 E2E_ADMIN_EMAIL=
 E2E_ADMIN_PASSWORD=
 
-# Test student. If unset, a per-run student
-#   <namespace>@inbox.dtcdev.click
-# is created admin-side and impersonated via django-loginas.
+# Test student. If unset, a per-run student at a Datamailer *mock address*
+#   e2e+<namespace>@mailbox.test
+# is created admin-side and impersonated via django-loginas. Sends to this
+# address are captured by the mock inbox instead of being delivered for real.
 E2E_STUDENT_EMAIL=
 E2E_STUDENT_PASSWORD=
 
-# Datamailer mock inbox (sub-task of #194). Leave unset until it exists;
-# email-verification tests xfail when unset.
+# Datamailer mock inbox (default email backend; #194 mock-inbox sub-task).
+# URL = the Datamailer service root (the client appends /api/mock-inbox/...).
+# Both fall back to DATAMAILER_URL / DATAMAILER_API_KEY in the repo-root .env.
+# Email tests xfail when neither is set.
 E2E_MOCK_INBOX_URL=
 E2E_MOCK_INBOX_API_KEY=
+# Mock-address shape (must match the datamailer MOCK_INBOX_* settings).
+E2E_MOCK_INBOX_DOMAIN=mailbox.test
+E2E_MOCK_INBOX_TAG=e2e
+
+# Real SES-inbound backend (#194 issue-194-ses-inbound). Not implemented yet;
+# the one/two real-backend email tests xfail until this lands. Leave unset.
+E2E_REAL_INBOX_URL=
+E2E_REAL_INBOX_API_KEY=
 
 # Optional: assert the deployed version matches the just-deployed build.
 E2E_EXPECTED_VERSION=

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,8 @@
+# Local secrets / overrides for the e2e suite. Never commit real credentials.
+.env
+# Playwright + pytest artifacts
+.pytest_cache/
+test-results/
+playwright-report/
+videos/
+traces/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -31,17 +31,50 @@ talks to the remote server over HTTP and a browser.
 | 3. Enrollment & identity (create/find student, impersonate, profile) | `tests/test_02_enrollment.py` | browser (loginas) |
 | 4. Homework flow (submit via UI, confirmation, score, leaderboard) | `tests/test_03_homework.py` | browser + API |
 | 5. Project flow (submit via UI, assign reviews, score, stats) | `tests/test_04_project.py` | browser + API |
-| 6. Email verification (homework + project confirmation emails) | `tests/test_03/04` (`@pytest.mark.email`) | **stub / xfail** |
+| 6. Email verification (homework + project confirmation emails) | `tests/test_03/04` (`@pytest.mark.email`) + `tests/test_06` (client unit tests) | mock-store (default) / real (xfail) |
 | 7. Dashboards & stats render | `tests/test_05_dashboards.py` | browser |
 | 8. Teardown + pre-run sweep + clean assert | `tests/test_99_teardown.py` | browser + API |
 
-### Email verification is stubbed (on purpose)
+### Email verification: two backends behind one interface
 
-The Datamailer **mock-inbox** endpoint (a separate #194 sub-task owned by the
-`datamailer/` repo) is not final. The email checks are written against a small
-`MockInboxClient.wait_for_message(address, subject=...)` abstraction
-(`mock_inbox.py`) and **xfail** until `E2E_MOCK_INBOX_URL` is set. Update the
-proposed contract in `mock_inbox.py` and set the env var to turn them on.
+Email checks go through `mock_inbox.py`, which exposes two backends with the
+same `wait_for_message(address, template_key=..., subject=...) -> InboxMessage`
+interface plus `clear(address)` (teardown):
+
+- **`MockInboxClient` (default).** A real HTTP client for the Datamailer
+  **mock-inbox** API (#194, `datamailer` branch `issue-194-mock-inbox`). Sends
+  to a *mock address* (`e2e+<tag>@mailbox.test`) are captured as
+  `TransactionalMessage` rows instead of being delivered, and this client
+  lists / fetches detail / clears them with retries + clear timeout errors.
+  Contract (base URL = the Datamailer service root, `Bearer` client key):
+  - `GET /api/mock-inbox/messages?address=<addr>&limit=25` → newest-first summaries
+  - `GET /api/mock-inbox/messages/{id}` → `{message:{…, html_body, text_body, context, metadata}}`
+  - `DELETE /api/mock-inbox/messages` `{address}` (or empty = clear all) → `{deleted_count}`
+- **`RealInboxClient` (stub).** Placeholder for a real SES-inbound round-trip
+  (#194 branch `issue-194-ses-inbound`). Its read contract isn't final, so it
+  reports itself unconfigured and the tests that select it **xfail**. Exactly
+  one test (`test_homework_confirmation_email_real_ses`, marked
+  `@pytest.mark.real_inbox`) uses it via the `email_backend` selector.
+
+**Backend selector.** The `email_backend` fixture resolves to `mock_inbox` by
+default; a test marked `@pytest.mark.real_inbox` (or parametrized with `"real"`)
+resolves to `real_inbox`. Most email assertions use the mock store; one uses
+the real backend.
+
+**What runs now vs. what's gated.** The client logic is covered by
+`tests/test_06_mock_inbox_client.py` (17 unit tests, no network — paths, auth,
+params, response shapes, poll/timeout, retries, disabled-deployment 404,
+clear). The **live** email assertions in `test_03/04` need the mock inbox
+**deployed to dev** with `MOCK_INBOX_ENABLED=1` and `E2E_MOCK_INBOX_*` creds
+(it falls back to `DATAMAILER_URL` / `DATAMAILER_API_KEY`). When neither is set
+they xfail; when set but the deployment has the mock inbox off, the endpoint
+returns `404 mock_inbox_disabled` and the poll times out. The real-SES test
+xfails until `issue-194-ses-inbound` and `E2E_REAL_INBOX_*` exist.
+
+The student email is set to a unique per-run mock address
+(`settings.mock_address(namespace)` → `e2e+<namespace>@mailbox.test`) and the
+captured messages are cleared via the `DELETE` endpoint in each email test's
+teardown.
 
 ### Teardown is best-effort by design (platform gap)
 
@@ -92,8 +125,10 @@ secrets. The suite also falls back to the **repo-root `.env`** for
 | `E2E_BASE_URL` | all | Defaults to `https://dev.courses.datatalks.club` (or `PUBLIC_BASE_URL`). |
 | `E2E_API_TOKEN` | provisioning/scoring/teardown | Staff token. Falls back to `DEV_AUTH_TOKEN`. |
 | `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` | browser flows | Staff account; logs in via the admin form (no OAuth). |
-| `E2E_STUDENT_EMAIL` / `E2E_STUDENT_PASSWORD` | optional | If unset, a per-run `<namespace>@inbox.dtcdev.click` student is created admin-side. |
-| `E2E_MOCK_INBOX_URL` / `E2E_MOCK_INBOX_API_KEY` | email checks | Leave unset until the mock inbox lands (#194); email tests xfail. |
+| `E2E_STUDENT_EMAIL` / `E2E_STUDENT_PASSWORD` | optional | If unset, a per-run `e2e+<namespace>@mailbox.test` mock-address student is created admin-side. |
+| `E2E_MOCK_INBOX_URL` / `E2E_MOCK_INBOX_API_KEY` | email checks (mock) | Datamailer service root + client key. Fall back to `DATAMAILER_URL` / `DATAMAILER_API_KEY`. Email tests xfail when both unset. |
+| `E2E_MOCK_INBOX_DOMAIN` / `E2E_MOCK_INBOX_TAG` | optional | Mock-address shape; default `mailbox.test` / `e2e`. Must match the datamailer `MOCK_INBOX_*` settings. |
+| `E2E_REAL_INBOX_URL` / `E2E_REAL_INBOX_API_KEY` | email checks (real SES) | Not implemented yet (#194 `issue-194-ses-inbound`); real-backend test xfails. |
 | `E2E_EXPECTED_VERSION` | optional | If set, asserts `/api/health/` version matches the just-deployed build. |
 | `E2E_HEADLESS` | optional | `0` to watch the browser locally. |
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,109 @@
+# E2E smoke tests (Playwright)
+
+End-to-end smoke suite that runs against a **live** CMP deployment (dev by
+default) after each deploy. It provisions a full course lifecycle, exercises
+the user-facing flows through a real browser, verifies scoring + leaderboard,
+and tears the data down again so dev stays clean.
+
+This suite is intentionally **separate from the Django unit tests**
+(`courses/tests`, `api/tests`, ...). It has its own `pytest.ini`, never sets
+`DJANGO_SETTINGS_MODULE`, and never touches the project database — it only
+talks to the remote server over HTTP and a browser.
+
+## Framework
+
+- **Python Playwright + pytest** (`playwright>=1.58.0`, already in the repo's
+  dev deps). Chosen over the JS runner so the suite stays in one language /
+  one toolchain with the rest of the repo (`uv`, `pytest`), can import nothing
+  from Django but reuse the same `.env`, and so CI only needs the existing
+  Python environment.
+- Provisioning, scoring, assertions and teardown go through the **REST API**
+  (fast, token-auth). The genuinely user-facing flows — admin login,
+  impersonation, homework/project submission forms, confirmation pages,
+  dashboards, leaderboards — go through the **browser**.
+
+## What it covers (issue #194)
+
+| Scenario | File | Driver |
+|----------|------|--------|
+| 1. Availability & auth (health, admin login, protected redirect) | `tests/test_00_availability.py` | API + browser |
+| 2. Course & content provisioning (course, homework w/ FF+CB+MC, project) | `tests/test_01_provisioning.py` | API |
+| 3. Enrollment & identity (create/find student, impersonate, profile) | `tests/test_02_enrollment.py` | browser (loginas) |
+| 4. Homework flow (submit via UI, confirmation, score, leaderboard) | `tests/test_03_homework.py` | browser + API |
+| 5. Project flow (submit via UI, assign reviews, score, stats) | `tests/test_04_project.py` | browser + API |
+| 6. Email verification (homework + project confirmation emails) | `tests/test_03/04` (`@pytest.mark.email`) | **stub / xfail** |
+| 7. Dashboards & stats render | `tests/test_05_dashboards.py` | browser |
+| 8. Teardown + pre-run sweep + clean assert | `tests/test_99_teardown.py` | browser + API |
+
+### Email verification is stubbed (on purpose)
+
+The Datamailer **mock-inbox** endpoint (a separate #194 sub-task owned by the
+`datamailer/` repo) is not final. The email checks are written against a small
+`MockInboxClient.wait_for_message(address, subject=...)` abstraction
+(`mock_inbox.py`) and **xfail** until `E2E_MOCK_INBOX_URL` is set. Update the
+proposed contract in `mock_inbox.py` and set the env var to turn them on.
+
+### Teardown is best-effort by design (platform gap)
+
+The API is read-only for submissions/enrollments/peer-reviews and has **no
+course DELETE**. So teardown:
+
+1. removes the student's project submission via the UI (the only remote way
+   to delete a submission), then deletes the now-empty project;
+2. closes + deletes homeworks/projects that have no submissions;
+3. parks the leftover course (`visible=false`, renamed `[DELETED] ...`) since
+   it cannot be deleted; the next run's **pre-run sweep** re-parks any stale
+   `e2e-smoke-*` courses.
+
+The post-run assertion verifies **no _visible_ `e2e-smoke-*` course remains**.
+A separate `test_namespaced_course_fully_purged` is `xfail`ed with a TODO
+referencing #194 — it will pass once the platform grows an admin/API delete
+path for full cleanup.
+
+## Running it
+
+From the **repo root**, using `uv` (repo convention):
+
+```bash
+# Everything (needs admin creds + token; see env vars below)
+cd e2e && uv run --project .. pytest -c pytest.ini
+
+# Just the no-credential availability checks (health, login page, redirect)
+cd e2e && uv run --project .. pytest -c pytest.ini tests/test_00_availability.py
+```
+
+Browser-driven tests **skip cleanly** (not error) when admin credentials are
+absent, so you can always run the API-only subset.
+
+First-time only, install the browser binary:
+
+```bash
+uv run playwright install chromium
+```
+
+## Required environment variables / CI secrets
+
+Copy `e2e/.env.example` to `e2e/.env` for local runs, or provide as CI
+secrets. The suite also falls back to the **repo-root `.env`** for
+`DEV_AUTH_TOKEN` and `PUBLIC_BASE_URL`.
+
+| Var | Required for | Notes |
+|-----|--------------|-------|
+| `E2E_BASE_URL` | all | Defaults to `https://dev.courses.datatalks.club` (or `PUBLIC_BASE_URL`). |
+| `E2E_API_TOKEN` | provisioning/scoring/teardown | Staff token. Falls back to `DEV_AUTH_TOKEN`. |
+| `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` | browser flows | Staff account; logs in via the admin form (no OAuth). |
+| `E2E_STUDENT_EMAIL` / `E2E_STUDENT_PASSWORD` | optional | If unset, a per-run `<namespace>@inbox.dtcdev.click` student is created admin-side. |
+| `E2E_MOCK_INBOX_URL` / `E2E_MOCK_INBOX_API_KEY` | email checks | Leave unset until the mock inbox lands (#194); email tests xfail. |
+| `E2E_EXPECTED_VERSION` | optional | If set, asserts `/api/health/` version matches the just-deployed build. |
+| `E2E_HEADLESS` | optional | `0` to watch the browser locally. |
+
+**Never hardcode secrets.** Nothing in this suite contains credentials.
+
+## Scheduling (post dev-deploy)
+
+Run the suite as a **post-deploy job** in the dev deploy workflow (see
+`.github/workflows/e2e-smoke-dev.yml`): it triggers on `workflow_run`
+completion of the dev deploy, waits for `/api/health/` to report the new
+version (`E2E_EXPECTED_VERSION`), runs the suite, and fails (alerting) with
+the exact scenario that broke. Alternatively, an EventBridge schedule
+(consistent with the deadline-reminder infra) can invoke the same command.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -76,22 +76,42 @@ The student email is set to a unique per-run mock address
 captured messages are cleared via the `DELETE` endpoint in each email test's
 teardown.
 
-### Teardown is best-effort by design (platform gap)
+### Teardown deletes the course via the Django admin UI
 
-The API is read-only for submissions/enrollments/peer-reviews and has **no
-course DELETE**. So teardown:
+The platform deliberately exposes **no course DELETE API endpoint** — a
+standing remote delete capability could let any API client/agent wipe too much
+data. Cleanup instead reuses the suite's authenticated admin Playwright session
+(the same one used for login + impersonation) and deletes the course through
+the **Django admin confirmation screen**
+(`/admin/courses/course/<pk>/delete/` → "Yes, I'm sure"). Deleting the `Course`
+cascades to **all** of its data (homeworks, questions, projects, submissions,
+answers, enrollments, peer reviews are all `on_delete=CASCADE`), so a single
+admin delete fully purges a run.
+
+So teardown:
 
 1. removes the student's project submission via the UI (the only remote way
-   to delete a submission), then deletes the now-empty project;
-2. closes + deletes homeworks/projects that have no submissions;
-3. parks the leftover course (`visible=false`, renamed `[DELETED] ...`) since
-   it cannot be deleted; the next run's **pre-run sweep** re-parks any stale
-   `e2e-smoke-*` courses.
+   to delete a submission), then stops impersonating;
+2. runs a best-effort API pre-pass on individually-deletable homeworks/projects
+   (informative only — the admin delete supersedes it);
+3. **deletes the course through the admin UI**, cascading everything away. The
+   course pk is resolved from the slug via the admin changelist (the API does
+   not return a course id). The next run's **pre-run sweep** admin-deletes any
+   stale `e2e-smoke-*` courses the same way.
 
-The post-run assertion verifies **no _visible_ `e2e-smoke-*` course remains**.
-A separate `test_namespaced_course_fully_purged` is `xfail`ed with a TODO
-referencing #194 — it will pass once the platform grows an admin/API delete
-path for full cleanup.
+Teardown stays robust: if the admin delete is unavailable (no admin creds) or
+fails, it falls back to **parking** the course (`visible=false`, renamed
+`[DELETED] ...`) and reports the residual, so dev still stays clean.
+
+The post-run assertions verify **no _visible_ `e2e-smoke-*` course remains**
+and that the course is **fully purged** (no longer retrievable via the API).
+The full-purge check requires admin creds; in the API-only subset it is
+skipped (the course is parked hidden instead).
+
+> **Teardown now depends on `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD`.** These
+> were already required for the browser login/impersonation flows; the admin
+> deletion in teardown uses the same session. Without them, teardown degrades
+> to the park-hidden fallback.
 
 ## Running it
 
@@ -124,7 +144,7 @@ secrets. The suite also falls back to the **repo-root `.env`** for
 |-----|--------------|-------|
 | `E2E_BASE_URL` | all | Defaults to `https://dev.courses.datatalks.club` (or `PUBLIC_BASE_URL`). |
 | `E2E_API_TOKEN` | provisioning/scoring/teardown | Staff token. Falls back to `DEV_AUTH_TOKEN`. |
-| `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` | browser flows | Staff account; logs in via the admin form (no OAuth). |
+| `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` | browser flows + teardown | Staff account; logs in via the admin form (no OAuth). Teardown deletes the course through the admin UI with this session; without it, teardown only parks the course hidden. |
 | `E2E_STUDENT_EMAIL` / `E2E_STUDENT_PASSWORD` | optional | If unset, a per-run `e2e+<namespace>@mailbox.test` mock-address student is created admin-side. |
 | `E2E_MOCK_INBOX_URL` / `E2E_MOCK_INBOX_API_KEY` | email checks (mock) | Datamailer service root + client key. Fall back to `DATAMAILER_URL` / `DATAMAILER_API_KEY`. Email tests xfail when both unset. |
 | `E2E_MOCK_INBOX_DOMAIN` / `E2E_MOCK_INBOX_TAG` | optional | Mock-address shape; default `mailbox.test` / `e2e`. Must match the datamailer `MOCK_INBOX_*` settings. |

--- a/e2e/__init__.py
+++ b/e2e/__init__.py
@@ -1,0 +1,7 @@
+"""End-to-end smoke test suite for the Course Management Platform.
+
+This package hits a *live* deployment (dev by default) and is intentionally
+kept out of the Django unit-test suite (``courses/tests`` etc.). It is run
+with its own pytest config under ``e2e/`` so it never touches the project
+database or the regular test run.
+"""

--- a/e2e/api_client.py
+++ b/e2e/api_client.py
@@ -1,0 +1,248 @@
+"""Thin REST client for the CMP API used for fast provisioning, scoring,
+assertions and teardown.
+
+Only the endpoints the suite actually needs are wrapped. Each call raises
+``ApiError`` with a clear, scenario-friendly message on unexpected status
+codes so failures point straight at the broken step.
+
+Auth: ``Authorization: Token <token>`` (staff token). See endpoints.md.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import requests
+
+
+class ApiError(RuntimeError):
+    def __init__(self, message: str, *, status: int | None = None, body: Any = None):
+        self.status = status
+        self.body = body
+        super().__init__(message)
+
+
+class CmpApiClient:
+    def __init__(self, base_url: str, token: str, *, timeout: float = 30.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Token {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        )
+
+    # -- low level -------------------------------------------------------
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}{path}"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any = None,
+        expected: tuple[int, ...] = (200, 201),
+        retries: int = 2,
+    ) -> requests.Response:
+        url = self._url(path)
+        last_exc: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                resp = self.session.request(
+                    method,
+                    url,
+                    data=json.dumps(json_body) if json_body is not None else None,
+                    timeout=self.timeout,
+                )
+            except requests.RequestException as exc:  # network blip
+                last_exc = exc
+                if attempt < retries:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                raise ApiError(
+                    f"{method} {path} failed after {retries + 1} attempts: {exc}"
+                ) from exc
+
+            # Retry transient 5xx once or twice.
+            if resp.status_code >= 500 and attempt < retries:
+                time.sleep(1.5 * (attempt + 1))
+                continue
+
+            if resp.status_code not in expected:
+                raise ApiError(
+                    f"{method} {path} returned {resp.status_code} "
+                    f"(expected {expected}): {resp.text[:500]}",
+                    status=resp.status_code,
+                    body=_safe_json(resp),
+                )
+            return resp
+
+        # Unreachable, but keeps type-checkers happy.
+        raise ApiError(f"{method} {path} failed: {last_exc}")
+
+    # -- health ----------------------------------------------------------
+    def health(self) -> dict:
+        resp = self._request("GET", "/api/health/", expected=(200,))
+        return resp.json()
+
+    # -- courses ---------------------------------------------------------
+    def list_courses(self) -> list[dict]:
+        resp = self._request("GET", "/api/courses/", expected=(200,))
+        return resp.json().get("courses", [])
+
+    def create_course(self, payload: dict) -> dict:
+        resp = self._request(
+            "POST", "/api/courses/", json_body=payload, expected=(201,)
+        )
+        return resp.json()
+
+    def get_course(self, slug: str) -> dict | None:
+        resp = self._request(
+            "GET", f"/api/courses/{slug}/", expected=(200, 404)
+        )
+        return resp.json() if resp.status_code == 200 else None
+
+    def update_course(self, slug: str, payload: dict) -> dict:
+        resp = self._request(
+            "PATCH", f"/api/courses/{slug}/", json_body=payload, expected=(200,)
+        )
+        return resp.json()
+
+    # -- homeworks -------------------------------------------------------
+    def create_homework(self, course_slug: str, payload: dict) -> dict:
+        resp = self._request(
+            "POST",
+            f"/api/courses/{course_slug}/homeworks/",
+            json_body=payload,
+            expected=(201,),
+        )
+        body = resp.json()
+        created = body.get("created", [])
+        if not created:
+            raise ApiError(
+                f"Homework creation returned no created records: {body}"
+            )
+        return created[0]
+
+    def list_homeworks(self, course_slug: str) -> list[dict]:
+        resp = self._request(
+            "GET", f"/api/courses/{course_slug}/homeworks/", expected=(200,)
+        )
+        return resp.json().get("homeworks", [])
+
+    def update_homework(self, course_slug: str, hw_id: int, payload: dict) -> dict:
+        resp = self._request(
+            "PATCH",
+            f"/api/courses/{course_slug}/homeworks/{hw_id}/",
+            json_body=payload,
+            expected=(200,),
+        )
+        return resp.json()
+
+    def delete_homework(self, course_slug: str, hw_id: int) -> requests.Response:
+        # 200 = deleted, 400 = blocked (has submissions / not closed).
+        return self._request(
+            "DELETE",
+            f"/api/courses/{course_slug}/homeworks/{hw_id}/",
+            expected=(200, 400, 404),
+        )
+
+    def score_homework(self, course_slug: str, hw_id: int) -> dict:
+        resp = self._request(
+            "POST",
+            f"/api/courses/{course_slug}/homeworks/{hw_id}/score/",
+            expected=(200, 400),
+        )
+        return resp.json()
+
+    def homework_submissions(self, course_slug: str, hw_slug: str) -> dict:
+        resp = self._request(
+            "GET",
+            f"/api/courses/{course_slug}/homeworks/{hw_slug}/submissions",
+            expected=(200,),
+        )
+        return resp.json()
+
+    # -- projects --------------------------------------------------------
+    def create_project(self, course_slug: str, payload: dict) -> dict:
+        resp = self._request(
+            "POST",
+            f"/api/courses/{course_slug}/projects/",
+            json_body=payload,
+            expected=(201,),
+        )
+        body = resp.json()
+        created = body.get("created", [])
+        if not created:
+            raise ApiError(
+                f"Project creation returned no created records: {body}"
+            )
+        return created[0]
+
+    def list_projects(self, course_slug: str) -> list[dict]:
+        resp = self._request(
+            "GET", f"/api/courses/{course_slug}/projects/", expected=(200,)
+        )
+        return resp.json().get("projects", [])
+
+    def update_project(self, course_slug: str, proj_id: int, payload: dict) -> dict:
+        resp = self._request(
+            "PATCH",
+            f"/api/courses/{course_slug}/projects/{proj_id}/",
+            json_body=payload,
+            expected=(200,),
+        )
+        return resp.json()
+
+    def delete_project(self, course_slug: str, proj_id: int) -> requests.Response:
+        return self._request(
+            "DELETE",
+            f"/api/courses/{course_slug}/projects/{proj_id}/",
+            expected=(200, 400, 404),
+        )
+
+    def assign_project_reviews(self, course_slug: str, proj_id: int) -> dict:
+        resp = self._request(
+            "POST",
+            f"/api/courses/{course_slug}/projects/{proj_id}/assign-reviews/",
+            expected=(200, 400),
+        )
+        return resp.json()
+
+    def score_project(self, course_slug: str, proj_id: int) -> dict:
+        resp = self._request(
+            "POST",
+            f"/api/courses/{course_slug}/projects/{proj_id}/score/",
+            expected=(200, 400),
+        )
+        return resp.json()
+
+    def project_submissions(self, course_slug: str, proj_slug: str) -> dict:
+        resp = self._request(
+            "GET",
+            f"/api/courses/{course_slug}/projects/{proj_slug}/submissions",
+            expected=(200,),
+        )
+        return resp.json()
+
+    # -- leaderboard -----------------------------------------------------
+    def leaderboard_yaml(self, course_slug: str) -> str:
+        resp = self._request(
+            "GET",
+            f"/api/courses/{course_slug}/leaderboard.yaml",
+            expected=(200,),
+        )
+        return resp.text
+
+
+def _safe_json(resp: requests.Response) -> Any:
+    try:
+        return resp.json()
+    except ValueError:
+        return resp.text

--- a/e2e/browser.py
+++ b/e2e/browser.py
@@ -163,6 +163,93 @@ class AdminSession:
             return existing
         return self.create_student(email, password)
 
+    # -- course teardown (admin side) ------------------------------------
+    def find_course_pk(self, slug: str, *, title: str | None = None) -> int | None:
+        """Resolve a Course primary key from its slug via the admin changelist.
+
+        ``CourseAdmin`` has no ``search_fields``, so the ``?q=`` search does
+        not filter -- the changelist lists every course. We therefore walk the
+        result rows and match ours by the row text (the namespaced ``slug`` is
+        embedded in the title ``E2E Smoke <slug>``; we also accept an explicit
+        ``title``), then read the ``<pk>`` out of that row's change link
+        (``/admin/courses/course/<pk>/change/``).
+        """
+        import re
+
+        self.page.goto(self.url("/admin/courses/course/"))
+        self.page.wait_for_load_state("networkidle")
+        needle = title or slug
+        # Each result row's first cell is an <a> to the change form. Find the
+        # row whose visible text contains our slug/title and read its pk.
+        rows = self.page.locator("#result_list tbody tr")
+        for i in range(rows.count()):
+            row = rows.nth(i)
+            try:
+                row_text = row.inner_text()
+            except Exception:
+                continue
+            if needle not in row_text and slug not in row_text:
+                continue
+            link = row.locator(
+                "a[href*='/admin/courses/course/']"
+            ).first
+            if link.count() == 0:
+                continue
+            href = link.get_attribute("href") or ""
+            m = re.search(r"/admin/courses/course/(\d+)/change/", href)
+            if m:
+                return int(m.group(1))
+        return None
+
+    def delete_course_via_admin(
+        self, slug: str, *, course_pk: int | None = None, title: str | None = None
+    ) -> bool:
+        """Delete a Course (and its cascade) through the Django admin UI.
+
+        Opens the admin delete-confirmation page
+        (``/admin/courses/course/<pk>/delete/``) and submits the "Yes, I'm
+        sure" form (which carries the CSRF token + ``post=yes``). Deleting the
+        Course cascades to all test data (homeworks, questions, projects,
+        submissions, answers, enrollments, peer reviews) because every FK back
+        to Course/Project is ``on_delete=CASCADE``.
+
+        This is the deliberate cleanup path: the platform intentionally has no
+        course DELETE API endpoint (a standing delete capability is unsafe), so
+        teardown reuses the interactive, staff-gated admin confirmation screen.
+
+        Returns ``True`` if the course is gone afterwards (change page 404s and
+        the changelist no longer lists it), ``False`` otherwise. Never raises.
+        """
+        try:
+            pk = course_pk
+            if pk is None:
+                pk = self.find_course_pk(slug, title=title)
+            if pk is None:
+                # Already absent -> nothing to delete; treat as success only
+                # if the changelist truly has no matching row.
+                return self.find_course_pk(slug, title=title) is None
+
+            self.page.goto(
+                self.url(f"/admin/courses/course/{pk}/delete/")
+            )
+            self.page.wait_for_load_state("networkidle")
+            # The confirmation page's submit button is inside a POST form that
+            # already carries csrfmiddlewaretoken + post=yes (Django renders a
+            # hidden <input name="post" value="yes">).
+            confirm = self.page.locator(
+                "form input[type='submit'], form button[type='submit']"
+            ).first
+            if confirm.count() == 0:
+                # Page may have 404'd (already deleted) -- verify and report.
+                return self.find_course_pk(slug, title=title) is None
+            confirm.click()
+            self.page.wait_for_load_state("networkidle")
+
+            # Verify: change page should 404 and changelist should not list it.
+            return self.find_course_pk(slug, title=title) is None
+        except Exception:
+            return False
+
     # -- homework flow ---------------------------------------------------
     def submit_homework(
         self,

--- a/e2e/browser.py
+++ b/e2e/browser.py
@@ -1,0 +1,300 @@
+"""Browser-side helpers built on Playwright sync API.
+
+Covers the user-facing flows the suite must validate through real pages:
+admin login form, django-loginas impersonation, homework submission, project
+submission, and reading rendered dashboards/leaderboards.
+
+All selectors use stable ``name``/``id`` attributes confirmed from the Django
+views and templates, not brittle text matching.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+
+class AdminSession:
+    """Drives an authenticated admin browser session.
+
+    Login is via the Django admin form (``/admin/login/``) -- never OAuth.
+    Impersonation uses django-loginas (``POST /admin/login/user/<id>/``).
+    """
+
+    def __init__(self, page: Page, base_url: str, ui_timeout_ms: int = 20000):
+        self.page = page
+        self.base_url = base_url.rstrip("/")
+        self.page.set_default_timeout(ui_timeout_ms)
+
+    def url(self, path: str) -> str:
+        return f"{self.base_url}{path}"
+
+    # -- auth ------------------------------------------------------------
+    def login_admin(self, email: str, password: str) -> None:
+        self.page.goto(self.url("/admin/login/"))
+        # Django admin login form: fields named username + password.
+        self.page.fill("input[name='username']", email)
+        self.page.fill("input[name='password']", password)
+        self.page.click("input[type='submit'], button[type='submit']")
+        self.page.wait_for_load_state("networkidle")
+        if "/admin/login" in self.page.url:
+            raise AssertionError(
+                "Admin login failed: still on the login page after submitting "
+                "credentials. Check E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD and "
+                "that the account is staff."
+            )
+
+    def impersonate(self, user_id: int | str) -> None:
+        """Switch the session to a student via django-loginas (POST + CSRF).
+
+        We submit a real form so the CSRF cookie/token handshake works the
+        same way the admin UI's "Login as user" button does.
+        """
+        self.page.goto(self.url(f"/admin/accounts/customuser/{user_id}/change/"))
+        # The change form template includes the loginas button/form.
+        loginas_button = self.page.locator(
+            "button[name='login_as'], input[name='login_as'], "
+            "form[action*='/admin/login/user/'] button, "
+            "form[action*='/admin/login/user/'] [type='submit']"
+        ).first
+        if loginas_button.count() == 0:
+            # Fallback: build the POST form ourselves using the CSRF cookie.
+            self._impersonate_via_fetch(user_id)
+            return
+        loginas_button.click()
+        self.page.wait_for_load_state("networkidle")
+
+    def _impersonate_via_fetch(self, user_id: int | str) -> None:
+        """Programmatic loginas POST using the session's CSRF token."""
+        result = self.page.evaluate(
+            """async (userId) => {
+                function getCookie(name) {
+                    const m = document.cookie.match(
+                        new RegExp('(^|; )' + name + '=([^;]*)'));
+                    return m ? decodeURIComponent(m[2]) : null;
+                }
+                const token = getCookie('csrftoken');
+                const resp = await fetch('/admin/login/user/' + userId + '/', {
+                    method: 'POST',
+                    headers: {'X-CSRFToken': token,
+                              'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: 'csrfmiddlewaretoken=' + encodeURIComponent(token),
+                    credentials: 'same-origin',
+                });
+                return resp.status;
+            }""",
+            user_id,
+        )
+        if result and int(result) >= 400:
+            raise AssertionError(
+                f"django-loginas impersonation POST returned HTTP {result} "
+                f"for user {user_id}."
+            )
+
+    def stop_impersonating(self) -> None:
+        self.page.evaluate(
+            """async () => {
+                function getCookie(name) {
+                    const m = document.cookie.match(
+                        new RegExp('(^|; )' + name + '=([^;]*)'));
+                    return m ? decodeURIComponent(m[2]) : null;
+                }
+                const token = getCookie('csrftoken');
+                await fetch('/accounts/stop-impersonating/', {
+                    method: 'POST',
+                    headers: {'X-CSRFToken': token || ''},
+                    credentials: 'same-origin',
+                });
+            }"""
+        )
+
+    # -- test student management (admin side) ----------------------------
+    def find_user_id_by_email(self, email: str) -> int | None:
+        """Look up a user id via the admin changelist search.
+
+        CustomUserAdmin has ``search_fields = ["email"]`` so the changelist
+        ``?q=`` search returns matching rows; we read the edit link id.
+        """
+        self.page.goto(
+            self.url(f"/admin/accounts/customuser/?q={email}")
+        )
+        self.page.wait_for_load_state("networkidle")
+        link = self.page.locator(
+            "a[href*='/admin/accounts/customuser/']"
+        ).filter(has_text="")
+        import re
+
+        for i in range(link.count()):
+            href = link.nth(i).get_attribute("href") or ""
+            m = re.search(r"/admin/accounts/customuser/(\d+)/change/", href)
+            if m:
+                return int(m.group(1))
+        return None
+
+    def create_student(self, email: str, password: str) -> int:
+        """Create a non-staff student via the admin add form.
+
+        The CustomUser add form (AbstractUser) asks for username + the two
+        password fields. Username is set to the email so login/lookup work.
+        """
+        self.page.goto(self.url("/admin/accounts/customuser/add/"))
+        self.page.wait_for_load_state("networkidle")
+        self.page.fill("input[name='username']", email)
+        self.page.fill("input[name='password1']", password)
+        self.page.fill("input[name='password2']", password)
+        self.page.click("input[name='_save'], button[type='submit'], "
+                        "input[type='submit']")
+        self.page.wait_for_load_state("networkidle")
+        # On the resulting change form, also set the email field if present.
+        if self.page.locator("input[name='email']").count():
+            self.page.fill("input[name='email']", email)
+            self.page.click("input[name='_save'], button[type='submit'], "
+                            "input[type='submit']")
+            self.page.wait_for_load_state("networkidle")
+        user_id = self.find_user_id_by_email(email)
+        if user_id is None:
+            raise AssertionError(
+                f"Created student {email} but could not find its user id."
+            )
+        return user_id
+
+    def ensure_student(self, email: str, password: str) -> int:
+        existing = self.find_user_id_by_email(email)
+        if existing is not None:
+            return existing
+        return self.create_student(email, password)
+
+    # -- homework flow ---------------------------------------------------
+    def submit_homework(
+        self,
+        course_slug: str,
+        homework_slug: str,
+        answers: dict[int, str],
+        *,
+        homework_url: str | None = None,
+        learning_in_public_links: list[str] | None = None,
+        time_spent_lectures: float | None = None,
+        time_spent_homework: float | None = None,
+    ) -> None:
+        page = self.page
+        page.goto(self.url(f"/{course_slug}/homework/{homework_slug}"))
+        page.wait_for_load_state("networkidle")
+
+        for question_id, value in answers.items():
+            field = f"answer_{question_id}"
+            # Radio (MC) / checkbox (CB): value is the 1-based option index.
+            radios = page.locator(
+                f"input[name='{field}'][type='radio'][value='{value}']"
+            )
+            checkboxes = page.locator(
+                f"input[name='{field}'][type='checkbox']"
+            )
+            if radios.count() > 0:
+                radios.first.check()
+            elif checkboxes.count() > 0:
+                for idx in str(value).split(","):
+                    idx = idx.strip()
+                    cb = page.locator(
+                        f"input[name='{field}'][type='checkbox'][value='{idx}']"
+                    )
+                    if cb.count() > 0:
+                        cb.first.check()
+            else:
+                # Free-form text / textarea.
+                page.fill(f"[name='{field}']", str(value))
+
+        if homework_url is not None and page.locator(
+            "[name='homework_url']"
+        ).count():
+            page.fill("[name='homework_url']", homework_url)
+        if time_spent_lectures is not None and page.locator(
+            "[name='time_spent_lectures']"
+        ).count():
+            page.fill("[name='time_spent_lectures']", str(time_spent_lectures))
+        if time_spent_homework is not None and page.locator(
+            "[name='time_spent_homework']"
+        ).count():
+            page.fill("[name='time_spent_homework']", str(time_spent_homework))
+        if learning_in_public_links:
+            inputs = page.locator("[name='learning_in_public_links[]']")
+            for i, link in enumerate(learning_in_public_links):
+                if i < inputs.count():
+                    inputs.nth(i).fill(link)
+
+        page.click("button[type='submit'], input[type='submit']")
+        page.wait_for_load_state("networkidle")
+
+    def homework_confirmation_text(self) -> str:
+        return self.page.locator("body").inner_text()
+
+    # -- project flow ----------------------------------------------------
+    def submit_project(
+        self,
+        course_slug: str,
+        project_slug: str,
+        *,
+        github_link: str,
+        commit_id: str,
+        certificate_name: str | None = None,
+        time_spent: float | None = None,
+        learning_in_public_links: list[str] | None = None,
+    ) -> None:
+        page = self.page
+        page.goto(self.url(f"/{course_slug}/project/{project_slug}"))
+        page.wait_for_load_state("networkidle")
+
+        page.fill("[name='github_link']", github_link)
+        page.fill("[name='commit_id']", commit_id)
+        if certificate_name is not None and page.locator(
+            "[name='certificate_name']"
+        ).count():
+            page.fill("[name='certificate_name']", certificate_name)
+        if time_spent is not None and page.locator("[name='time_spent']").count():
+            page.fill("[name='time_spent']", str(time_spent))
+        if learning_in_public_links:
+            inputs = page.locator("[name='learning_in_public_links[]']")
+            for i, link in enumerate(learning_in_public_links):
+                if i < inputs.count():
+                    inputs.nth(i).fill(link)
+
+        page.click("#project-form button[type='submit'], "
+                   "#project-form input[type='submit']")
+        page.wait_for_load_state("networkidle")
+
+    def delete_project_submission(self, course_slug: str, project_slug: str) -> None:
+        """Delete the impersonated student's own project submission via the UI.
+
+        The project view accepts ``action=delete`` on POST. We post it with
+        the page CSRF token. This is the only remote way to remove a
+        submission so the project becomes deletable again.
+        """
+        page = self.page
+        page.goto(self.url(f"/{course_slug}/project/{project_slug}"))
+        page.evaluate(
+            """async () => {
+                function getCookie(name) {
+                    const m = document.cookie.match(
+                        new RegExp('(^|; )' + name + '=([^;]*)'));
+                    return m ? decodeURIComponent(m[2]) : null;
+                }
+                const token = getCookie('csrftoken');
+                await fetch(window.location.pathname, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: 'csrfmiddlewaretoken=' + encodeURIComponent(token) +
+                          '&action=delete',
+                    credentials: 'same-origin',
+                });
+            }"""
+        )
+
+    # -- read-only pages -------------------------------------------------
+    def open(self, path: str) -> str:
+        self.page.goto(self.url(path))
+        self.page.wait_for_load_state("networkidle")
+        return self.page.locator("body").inner_text()
+
+    def expect_redirect_to_login(self, path: str) -> None:
+        self.page.goto(self.url(path))
+        expect(self.page).to_have_url(
+            __import__("re").compile(r"/login(/|\?|$)")
+        )

--- a/e2e/config.py
+++ b/e2e/config.py
@@ -1,0 +1,119 @@
+"""Runtime configuration for the e2e smoke suite.
+
+Everything sensitive (admin password, API token) comes from environment
+variables / CI secrets. Nothing is hardcoded. Loading order:
+
+1. Process environment (CI secrets).
+2. ``e2e/.env`` if present (local convenience, gitignored).
+3. The repo-root ``.env`` (dev API token + base URLs live here already).
+
+Required vars are validated lazily so that ``--collect-only`` and the
+health-check test can run even when full credentials are missing.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Namespace prefix used for every resource the suite creates. The pre-run
+# sweep and post-run assertions key off this exact string, so do not change
+# it without updating the teardown logic.
+NAMESPACE_PREFIX = "e2e-smoke-"
+
+
+def _load_dotenv(path: Path) -> None:
+    """Minimal .env loader (no external dependency).
+
+    Only sets keys that are not already present in the environment, so real
+    CI secrets always win over file values.
+    """
+    if not path.exists():
+        return
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def _ensure_env_loaded() -> None:
+    _load_dotenv(Path(__file__).resolve().parent / ".env")
+    _load_dotenv(REPO_ROOT / ".env")
+
+
+class ConfigError(RuntimeError):
+    """Raised when a required configuration value is missing."""
+
+
+@dataclass(frozen=True)
+class Settings:
+    base_url: str
+    api_token: str | None
+    admin_email: str | None
+    admin_password: str | None
+    student_email: str | None
+    student_password: str | None
+    mock_inbox_url: str | None
+    mock_inbox_api_key: str | None
+    request_timeout: float
+    ui_timeout_ms: int
+    expected_version: str | None
+
+    def require_api_token(self) -> str:
+        if not self.api_token:
+            raise ConfigError(
+                "E2E_API_TOKEN (or DEV_AUTH_TOKEN in .env) is required for "
+                "API provisioning/teardown but was not set."
+            )
+        return self.api_token
+
+    def require_admin(self) -> tuple[str, str]:
+        if not self.admin_email or not self.admin_password:
+            raise ConfigError(
+                "E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD are required for the "
+                "browser flows (admin login + impersonation) but were not set."
+            )
+        return self.admin_email, self.admin_password
+
+
+def _first_env(*names: str) -> str | None:
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def load_settings() -> Settings:
+    _ensure_env_loaded()
+
+    # Default to dev; PUBLIC_BASE_URL in the repo .env already points at dev.
+    base_url = _first_env(
+        "E2E_BASE_URL", "PUBLIC_BASE_URL"
+    ) or "https://dev.courses.datatalks.club"
+    base_url = base_url.rstrip("/")
+
+    return Settings(
+        base_url=base_url,
+        # Prefer an explicit e2e token; fall back to the dev token in .env.
+        api_token=_first_env("E2E_API_TOKEN", "DEV_AUTH_TOKEN"),
+        admin_email=_first_env("E2E_ADMIN_EMAIL"),
+        admin_password=_first_env("E2E_ADMIN_PASSWORD"),
+        student_email=_first_env("E2E_STUDENT_EMAIL"),
+        student_password=_first_env("E2E_STUDENT_PASSWORD"),
+        mock_inbox_url=_first_env("E2E_MOCK_INBOX_URL"),
+        mock_inbox_api_key=_first_env(
+            "E2E_MOCK_INBOX_API_KEY", "DATAMAILER_API_KEY"
+        ),
+        request_timeout=float(_first_env("E2E_REQUEST_TIMEOUT") or "30"),
+        ui_timeout_ms=int(_first_env("E2E_UI_TIMEOUT_MS") or "20000"),
+        expected_version=_first_env("E2E_EXPECTED_VERSION"),
+    )

--- a/e2e/config.py
+++ b/e2e/config.py
@@ -63,9 +63,24 @@ class Settings:
     student_password: str | None
     mock_inbox_url: str | None
     mock_inbox_api_key: str | None
+    mock_inbox_domain: str
+    mock_inbox_tag: str
+    real_inbox_url: str | None
+    real_inbox_api_key: str | None
     request_timeout: float
     ui_timeout_ms: int
     expected_version: str | None
+
+    def mock_address(self, label: str) -> str:
+        """Build a plus-tagged mock address the Datamailer mock inbox captures.
+
+        Shape: ``<tag>+<label>@<domain>`` (e.g. ``e2e+e2e-smoke-123@mailbox.test``).
+        The datamailer side recognises an address as "mock" when its domain is
+        ``MOCK_INBOX_DOMAIN`` *or* its local part carries ``MOCK_INBOX_PLUS_TAG``.
+        Using both keeps it a mock address regardless of which check fires.
+        """
+        clean = "".join(c if (c.isalnum() or c in "-._") else "-" for c in label)
+        return f"{self.mock_inbox_tag}+{clean}@{self.mock_inbox_domain}"
 
     def require_api_token(self) -> str:
         if not self.api_token:
@@ -109,10 +124,24 @@ def load_settings() -> Settings:
         admin_password=_first_env("E2E_ADMIN_PASSWORD"),
         student_email=_first_env("E2E_STUDENT_EMAIL"),
         student_password=_first_env("E2E_STUDENT_PASSWORD"),
-        mock_inbox_url=_first_env("E2E_MOCK_INBOX_URL"),
+        # Mock inbox: base URL is the Datamailer service root (the client
+        # appends /api/mock-inbox/...). Fall back to the datamailer settings
+        # already present in the repo .env.
+        mock_inbox_url=_first_env("E2E_MOCK_INBOX_URL", "DATAMAILER_URL"),
         mock_inbox_api_key=_first_env(
             "E2E_MOCK_INBOX_API_KEY", "DATAMAILER_API_KEY"
         ),
+        mock_inbox_domain=(
+            _first_env("E2E_MOCK_INBOX_DOMAIN", "MOCK_INBOX_DOMAIN")
+            or "mailbox.test"
+        ),
+        mock_inbox_tag=(
+            _first_env("E2E_MOCK_INBOX_TAG", "MOCK_INBOX_PLUS_TAG") or "e2e"
+        ),
+        # Real SES-inbound backend (issue-194-ses-inbound). Unset until ready;
+        # the one/two tests using it skip/xfail.
+        real_inbox_url=_first_env("E2E_REAL_INBOX_URL"),
+        real_inbox_api_key=_first_env("E2E_REAL_INBOX_API_KEY"),
         request_timeout=float(_first_env("E2E_REQUEST_TIMEOUT") or "30"),
         ui_timeout_ms=int(_first_env("E2E_UI_TIMEOUT_MS") or "20000"),
         expected_version=_first_env("E2E_EXPECTED_VERSION"),

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,143 @@
+"""Shared fixtures for the e2e smoke suite.
+
+The suite runs as one ordered scenario (provision -> enroll -> submit ->
+score -> verify -> teardown), so most fixtures are session-scoped and a
+single ``RunState`` object threads data between test modules. Each test file
+maps to a numbered scenario from issue #194 and is named to sort in order.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+# Allow ``import e2e.<module>`` when pytest is invoked from inside e2e/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from e2e.api_client import CmpApiClient  # noqa: E402
+from e2e.config import load_settings, Settings  # noqa: E402
+from e2e.mock_inbox import MockInboxClient  # noqa: E402
+from e2e.provisioning import (  # noqa: E402
+    ProvisionedCourse,
+    Provisioner,
+    make_namespace,
+)
+
+
+@dataclass
+class RunState:
+    namespace: str
+    course: ProvisionedCourse | None = None
+    student_email: str | None = None
+    student_user_id: int | str | None = None
+    teardown_report: dict = field(default_factory=dict)
+    # Flags set by earlier scenarios so later ones can skip cleanly.
+    homework_submitted: bool = False
+    project_submitted: bool = False
+
+
+@pytest.fixture(scope="session")
+def settings() -> Settings:
+    return load_settings()
+
+
+@pytest.fixture(scope="session")
+def api(settings: Settings) -> CmpApiClient:
+    return CmpApiClient(
+        settings.base_url,
+        settings.require_api_token(),
+        timeout=settings.request_timeout,
+    )
+
+
+@pytest.fixture(scope="session")
+def provisioner(api: CmpApiClient) -> Provisioner:
+    return Provisioner(api)
+
+
+@pytest.fixture(scope="session")
+def mock_inbox(settings: Settings) -> MockInboxClient:
+    return MockInboxClient(settings.mock_inbox_url, settings.mock_inbox_api_key)
+
+
+@pytest.fixture(scope="session")
+def run_state() -> RunState:
+    return RunState(namespace=make_namespace(int(time.time())))
+
+
+@pytest.fixture(scope="session")
+def due_dates() -> dict:
+    """ISO dates used for homework/project deadlines (well in the future)."""
+    future = time.gmtime(time.time() + 90 * 24 * 3600)
+    far = time.gmtime(time.time() + 120 * 24 * 3600)
+    fmt = "%Y-%m-%d"
+    return {
+        "homework_due": time.strftime(fmt, future),
+        "project_due": time.strftime(fmt, future),
+        "peer_review_due": time.strftime(fmt, far),
+    }
+
+
+# -- session-scoped Playwright browser/context/page -----------------------
+# pytest-playwright's built-in fixtures are function-scoped; the smoke
+# scenario needs one persistent authenticated context across tests, so we
+# build our own session-scoped page from the sync API.
+@pytest.fixture(scope="session")
+def admin_page(settings: Settings):
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:  # pragma: no cover
+        pytest.skip("Playwright is not installed")
+
+    headless_env = __import__("os").environ.get("E2E_HEADLESS", "1")
+    headless = headless_env not in ("0", "false", "False")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=headless)
+        context = browser.new_context(
+            base_url=settings.base_url,
+            ignore_https_errors=False,
+        )
+        page = context.new_page()
+        page.set_default_timeout(settings.ui_timeout_ms)
+        yield page
+        context.close()
+        browser.close()
+
+
+@pytest.fixture(scope="session")
+def admin_creds(settings: Settings):
+    """Admin email/password, or skip the test cleanly when not configured.
+
+    Browser-driven scenarios require an admin account; in environments where
+    the secret is intentionally absent (e.g. a structural dry run) we skip
+    with a clear message rather than erroring.
+    """
+    if not settings.admin_email or not settings.admin_password:
+        pytest.skip(
+            "E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD not set; skipping "
+            "browser-driven scenario (admin login + impersonation required)."
+        )
+    return settings.admin_email, settings.admin_password
+
+
+@pytest.fixture(scope="session")
+def admin_session(admin_page, settings: Settings, admin_creds):
+    """Authenticated admin browser session (logs in once per session)."""
+    from e2e.browser import AdminSession
+
+    email, password = admin_creds
+    session = AdminSession(admin_page, settings.base_url, settings.ui_timeout_ms)
+    session.login_admin(email, password)
+    return session
+
+
+def require(value, message: str):
+    """Skip the current test with a clear message when a prereq is missing."""
+    if not value:
+        pytest.skip(message)
+    return value

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from e2e.api_client import CmpApiClient  # noqa: E402
 from e2e.config import load_settings, Settings  # noqa: E402
-from e2e.mock_inbox import MockInboxClient  # noqa: E402
+from e2e.mock_inbox import MockInboxClient, RealInboxClient  # noqa: E402
 from e2e.provisioning import (  # noqa: E402
     ProvisionedCourse,
     Provisioner,
@@ -62,6 +62,28 @@ def provisioner(api: CmpApiClient) -> Provisioner:
 @pytest.fixture(scope="session")
 def mock_inbox(settings: Settings) -> MockInboxClient:
     return MockInboxClient(settings.mock_inbox_url, settings.mock_inbox_api_key)
+
+
+@pytest.fixture(scope="session")
+def real_inbox(settings: Settings) -> RealInboxClient:
+    return RealInboxClient(settings.real_inbox_url, settings.real_inbox_api_key)
+
+
+@pytest.fixture(scope="session")
+def email_backend(request):
+    """Resolve the email-verification backend for a test.
+
+    Default = the fast mock-store backend (``mock_inbox``). A test opts into the
+    real SES round-trip backend by parametrizing or marking itself with
+    ``real`` (``@pytest.mark.real_inbox``); it then resolves to ``real_inbox``.
+    Either way, the test gets one object implementing the same interface.
+    """
+    backend = getattr(request, "param", None)
+    if backend is None:
+        marker = request.node.get_closest_marker("real_inbox")
+        backend = "real" if marker else "mock"
+    fixture_name = "real_inbox" if backend == "real" else "mock_inbox"
+    return request.getfixturevalue(fixture_name)
 
 
 @pytest.fixture(scope="session")

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -158,6 +158,24 @@ def admin_session(admin_page, settings: Settings, admin_creds):
     return session
 
 
+@pytest.fixture(scope="session")
+def optional_admin_session(request, settings: Settings):
+    """The admin session if admin creds are configured, else ``None``.
+
+    Teardown and the pre-run sweep delete the course through the admin UI, but
+    must still run in the API-only subset (no admin creds) -- there they fall
+    back to parking the course hidden. Unlike ``admin_session``, this fixture
+    never skips: it returns ``None`` when creds are absent or login fails, so
+    callers can degrade gracefully instead of erroring.
+    """
+    if not settings.admin_email or not settings.admin_password:
+        return None
+    try:
+        return request.getfixturevalue("admin_session")
+    except Exception:
+        return None
+
+
 def require(value, message: str):
     """Skip the current test with a clear message when a prereq is missing."""
     if not value:

--- a/e2e/mock_inbox.py
+++ b/e2e/mock_inbox.py
@@ -1,0 +1,124 @@
+"""Client abstraction for the Datamailer *mock inbox* API.
+
+The mock-inbox endpoint is a separate, in-progress sub-task of issue #194
+(owned by the Datamailer repo, which this suite must NOT modify). The wire
+contract is not final, so this client is deliberately small and clearly
+marked. Tests that depend on it are skipped/xfailed until the real endpoint
+exists and ``E2E_MOCK_INBOX_URL`` is configured.
+
+Expected (proposed) contract -- adjust here once finalized, see #194:
+
+    GET {mock_inbox_url}/messages?address=<email>
+    Authorization: Bearer <api_key>
+    -> 200 {"messages": [
+            {"to": "...", "subject": "...", "html": "...", "text": "...",
+             "headers": {...}, "received_at": "..."}, ...]}
+
+``wait_for_message`` polls that endpoint until a message matching the
+address (and optionally a subject substring) appears, or a timeout elapses.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import requests
+
+
+class MockInboxNotConfigured(RuntimeError):
+    """Raised when the mock inbox URL has not been provided yet."""
+
+
+class MockInboxTimeout(AssertionError):
+    """Raised when no matching message arrives within the timeout."""
+
+
+@dataclass
+class InboxMessage:
+    to: str
+    subject: str
+    html: str
+    text: str
+    raw: dict
+
+    def body_contains(self, needle: str) -> bool:
+        return needle in (self.html or "") or needle in (self.text or "")
+
+
+class MockInboxClient:
+    def __init__(
+        self,
+        base_url: str | None,
+        api_key: str | None = None,
+        *,
+        timeout: float = 15.0,
+    ):
+        self.base_url = base_url.rstrip("/") if base_url else None
+        self.api_key = api_key
+        self.timeout = timeout
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.base_url)
+
+    def _headers(self) -> dict:
+        headers = {"Accept": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def list_messages(self, address: str) -> list[InboxMessage]:
+        if not self.configured:
+            raise MockInboxNotConfigured(
+                "E2E_MOCK_INBOX_URL is not set; the Datamailer mock inbox "
+                "endpoint is not available yet (see issue #194)."
+            )
+        resp = requests.get(
+            f"{self.base_url}/messages",
+            params={"address": address},
+            headers=self._headers(),
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        items = payload.get("messages", payload if isinstance(payload, list) else [])
+        return [
+            InboxMessage(
+                to=item.get("to", address),
+                subject=item.get("subject", ""),
+                html=item.get("html", ""),
+                text=item.get("text", ""),
+                raw=item,
+            )
+            for item in items
+        ]
+
+    def wait_for_message(
+        self,
+        address: str,
+        *,
+        subject: str | None = None,
+        body_contains: str | None = None,
+        timeout: float = 60.0,
+        poll_interval: float = 3.0,
+    ) -> InboxMessage:
+        """Poll until a matching message arrives or ``timeout`` elapses."""
+        deadline = time.monotonic() + timeout
+        last_seen: list[InboxMessage] = []
+        while time.monotonic() < deadline:
+            last_seen = self.list_messages(address)
+            for message in last_seen:
+                if subject and subject not in message.subject:
+                    continue
+                if body_contains and not message.body_contains(body_contains):
+                    continue
+                return message
+            time.sleep(poll_interval)
+
+        subjects = [m.subject for m in last_seen]
+        raise MockInboxTimeout(
+            f"No email to {address} matching subject={subject!r} / "
+            f"body~={body_contains!r} arrived within {timeout}s. "
+            f"Seen subjects: {subjects}"
+        )

--- a/e2e/mock_inbox.py
+++ b/e2e/mock_inbox.py
@@ -1,52 +1,338 @@
-"""Client abstraction for the Datamailer *mock inbox* API.
+"""Email-verification clients for the e2e smoke suite.
 
-The mock-inbox endpoint is a separate, in-progress sub-task of issue #194
-(owned by the Datamailer repo, which this suite must NOT modify). The wire
-contract is not final, so this client is deliberately small and clearly
-marked. Tests that depend on it are skipped/xfailed until the real endpoint
-exists and ``E2E_MOCK_INBOX_URL`` is configured.
+Two backends sit behind one interface (:class:`InboxBackend`) so the email
+tests don't care which one they run against:
 
-Expected (proposed) contract -- adjust here once finalized, see #194:
+* :class:`MockInboxClient` -- the **default**, fast, deterministic backend. It
+  talks to the Datamailer *mock inbox* API (issue #194, owned by the
+  ``datamailer/`` repo). Transactional sends to a recognised "mock address"
+  (``e2e+<tag>@mailbox.test`` or ``e2e+<tag>@<dev-domain>``) are captured as
+  ``TransactionalMessage`` rows instead of being delivered for real, and this
+  client lists / fetches / clears them over HTTP.
 
-    GET {mock_inbox_url}/messages?address=<email>
-    Authorization: Bearer <api_key>
-    -> 200 {"messages": [
-            {"to": "...", "subject": "...", "html": "...", "text": "...",
-             "headers": {...}, "received_at": "..."}, ...]}
+* :class:`RealInboxClient` -- a **stub** for a real SES inbound round-trip
+  (issue #194 sub-task ``issue-194-ses-inbound``). Its read contract is not
+  final yet, so this client is intentionally not implemented; one or two tests
+  opt into it and skip/xfail until ``E2E_REAL_INBOX_*`` config is provided.
 
-``wait_for_message`` polls that endpoint until a message matching the
-address (and optionally a subject substring) appears, or a timeout elapses.
+Mock-inbox wire contract (datamailer ``issue-194-mock-inbox``), base URL is the
+Datamailer service root (``E2E_MOCK_INBOX_URL`` / ``DATAMAILER_URL``), auth is
+``Authorization: Bearer <client api key>``:
+
+    GET    {base}/api/mock-inbox/messages?address=<addr>&limit=25
+        -> 200 {"address","count","messages":[{id,email,from_email,subject,
+                template_key,status,idempotency_key,created_at}, ...]}  (newest first)
+    GET    {base}/api/mock-inbox/messages/{id}
+        -> 200 {"message":{...summary..., html_body, text_body, context, metadata}}
+    DELETE {base}/api/mock-inbox/messages   body {"address":"<addr>"} (or empty = clear all)
+        -> 200 {"address","deleted_count"}
+
+When the mock inbox is disabled on the deployment, every route returns
+``404 {"error": {"code": "mock_inbox_disabled"}}``.
 """
 
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import requests
 
+MOCK_INBOX_PATH = "/api/mock-inbox/messages"
 
-class MockInboxNotConfigured(RuntimeError):
-    """Raised when the mock inbox URL has not been provided yet."""
+
+class InboxNotConfigured(RuntimeError):
+    """Raised when a backend's URL/key has not been provided yet."""
+
+
+class InboxDisabled(RuntimeError):
+    """Raised when the deployment has the mock inbox turned off (404)."""
 
 
 class MockInboxTimeout(AssertionError):
     """Raised when no matching message arrives within the timeout."""
 
 
+# Backwards-compatible alias (kept so older imports keep working).
+MockInboxNotConfigured = InboxNotConfigured
+
+
 @dataclass
 class InboxMessage:
+    """A captured email, normalised across backends.
+
+    ``raw`` holds the backend's original summary dict; ``html_body`` /
+    ``text_body`` / ``context`` are only populated once a detail fetch happens
+    (the list endpoint returns summaries only).
+    """
+
+    id: int | str | None
     to: str
     subject: str
-    html: str
-    text: str
-    raw: dict
+    template_key: str = ""
+    status: str = ""
+    from_email: str = ""
+    idempotency_key: str = ""
+    created_at: str = ""
+    html_body: str = ""
+    text_body: str = ""
+    context: dict = field(default_factory=dict)
+    metadata: dict = field(default_factory=dict)
+    raw: dict = field(default_factory=dict)
+
+    @property
+    def detail_loaded(self) -> bool:
+        return bool(self.html_body or self.text_body or self.context)
 
     def body_contains(self, needle: str) -> bool:
-        return needle in (self.html or "") or needle in (self.text or "")
+        """True if ``needle`` appears in the rendered bodies or the context.
+
+        Confirmation links live in ``context`` (e.g. ``update_url``) as well as
+        the rendered HTML, so we check both.
+        """
+        haystacks = [self.html_body or "", self.text_body or ""]
+        haystacks.extend(self._context_strings())
+        return any(needle in h for h in haystacks)
+
+    def _context_strings(self) -> list[str]:
+        out: list[str] = []
+        for value in (self.context or {}).values():
+            if isinstance(value, str):
+                out.append(value)
+            elif isinstance(value, (list, tuple)):
+                out.extend(str(v) for v in value)
+        return out
 
 
-class MockInboxClient:
+class InboxBackend:
+    """Common interface implemented by both backends."""
+
+    name = "inbox"
+
+    @property
+    def configured(self) -> bool:  # pragma: no cover - trivial
+        raise NotImplementedError
+
+    def list_messages(self, address: str, *, limit: int = 25) -> list[InboxMessage]:
+        raise NotImplementedError
+
+    def get_message(self, message_id) -> InboxMessage:
+        raise NotImplementedError
+
+    def clear(self, address: str | None = None) -> int:
+        raise NotImplementedError
+
+    def wait_for_message(
+        self,
+        address: str,
+        *,
+        template_key: str | None = None,
+        subject: str | None = None,
+        body_contains: str | None = None,
+        timeout: float = 90.0,
+        poll_interval: float = 3.0,
+        load_detail: bool = True,
+    ) -> InboxMessage:
+        """Poll until a matching message arrives or ``timeout`` elapses.
+
+        Matching is by ``template_key`` (exact), ``subject`` (substring) and/or
+        ``body_contains`` (substring across bodies + context). When
+        ``load_detail`` is set, the matched message's full detail (bodies +
+        context) is fetched before returning so callers can assert on links.
+        """
+        deadline = time.monotonic() + timeout
+        last_seen: list[InboxMessage] = []
+        last_error: Exception | None = None
+
+        while time.monotonic() < deadline:
+            try:
+                last_seen = self.list_messages(address)
+            except (requests.RequestException, InboxDisabled) as exc:
+                # Transient network hiccup or a not-yet-ready deployment: keep
+                # polling until the deadline rather than failing immediately.
+                last_error = exc
+                time.sleep(poll_interval)
+                continue
+
+            for message in last_seen:
+                if template_key and message.template_key != template_key:
+                    continue
+                if subject and subject not in message.subject:
+                    continue
+                if body_contains:
+                    candidate = message
+                    if load_detail and not message.detail_loaded:
+                        candidate = self.get_message(message.id)
+                    if not candidate.body_contains(body_contains):
+                        continue
+                    if load_detail:
+                        return candidate
+                    return message
+                if load_detail and message.id is not None:
+                    return self.get_message(message.id)
+                return message
+
+            time.sleep(poll_interval)
+
+        seen = [(m.template_key, m.subject) for m in last_seen]
+        hint = f" Last error: {last_error!r}." if last_error else ""
+        raise MockInboxTimeout(
+            f"[{self.name}] No email to {address} matching "
+            f"template_key={template_key!r} / subject={subject!r} / "
+            f"body~={body_contains!r} within {timeout}s. Seen: {seen}.{hint}"
+        )
+
+
+class MockInboxClient(InboxBackend):
+    """HTTP client for the Datamailer mock-inbox API (default backend)."""
+
+    name = "mock"
+
+    def __init__(
+        self,
+        base_url: str | None,
+        api_key: str | None = None,
+        *,
+        timeout: float = 15.0,
+        max_retries: int = 3,
+        retry_backoff: float = 0.5,
+    ):
+        self.base_url = base_url.rstrip("/") if base_url else None
+        self.api_key = api_key
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.retry_backoff = retry_backoff
+        self._session = requests.Session()
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.base_url and self.api_key)
+
+    @property
+    def messages_url(self) -> str:
+        return f"{self.base_url}{MOCK_INBOX_PATH}"
+
+    def _headers(self) -> dict:
+        headers = {"Accept": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _require_configured(self) -> None:
+        if not self.configured:
+            raise InboxNotConfigured(
+                "E2E_MOCK_INBOX_URL / E2E_MOCK_INBOX_API_KEY (falling back to "
+                "DATAMAILER_URL / DATAMAILER_API_KEY) are not set; the "
+                "Datamailer mock inbox is not reachable (see issue #194)."
+            )
+
+    def _request(self, method: str, url: str, **kwargs) -> requests.Response:
+        """Issue a request with retries on transient transport/5xx errors."""
+        self._require_configured()
+        kwargs.setdefault("headers", self._headers())
+        kwargs.setdefault("timeout", self.timeout)
+        last_exc: Exception | None = None
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                resp = self._session.request(method, url, **kwargs)
+            except requests.RequestException as exc:
+                last_exc = exc
+                if attempt == self.max_retries:
+                    raise
+                time.sleep(self.retry_backoff * attempt)
+                continue
+
+            if resp.status_code == 404 and self._looks_disabled(resp):
+                raise InboxDisabled(
+                    "Mock inbox is disabled on this deployment "
+                    "(MOCK_INBOX_ENABLED is off). 404 mock_inbox_disabled."
+                )
+            if resp.status_code >= 500 and attempt < self.max_retries:
+                last_exc = requests.HTTPError(f"{resp.status_code} from mock inbox")
+                time.sleep(self.retry_backoff * attempt)
+                continue
+            return resp
+
+        # Unreachable, but keeps type-checkers happy.
+        raise last_exc or RuntimeError("mock inbox request failed")
+
+    @staticmethod
+    def _looks_disabled(resp: requests.Response) -> bool:
+        try:
+            body = resp.json()
+        except ValueError:
+            return False
+        return (body.get("error") or {}).get("code") == "mock_inbox_disabled"
+
+    def list_messages(self, address: str, *, limit: int = 25) -> list[InboxMessage]:
+        resp = self._request(
+            "GET", self.messages_url, params={"address": address, "limit": limit}
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        items = payload.get("messages", []) if isinstance(payload, dict) else []
+        return [self._summary_to_message(item, address) for item in items]
+
+    def get_message(self, message_id) -> InboxMessage:
+        resp = self._request("GET", f"{self.messages_url}/{message_id}")
+        resp.raise_for_status()
+        payload = resp.json()
+        item = payload.get("message", payload) if isinstance(payload, dict) else {}
+        return self._detail_to_message(item)
+
+    def clear(self, address: str | None = None) -> int:
+        """Delete captured messages for ``address`` (or all when ``None``)."""
+        body: dict = {}
+        if address:
+            body["address"] = address
+        try:
+            resp = self._request("DELETE", self.messages_url, json=body)
+        except (InboxNotConfigured, InboxDisabled):
+            # Teardown must never explode; nothing to clear if unreachable.
+            return 0
+        if resp.status_code >= 400:
+            return 0
+        try:
+            return int(resp.json().get("deleted_count", 0))
+        except (ValueError, AttributeError, TypeError):
+            return 0
+
+    @staticmethod
+    def _summary_to_message(item: dict, address: str) -> InboxMessage:
+        return InboxMessage(
+            id=item.get("id"),
+            to=item.get("email", address),
+            subject=item.get("subject", ""),
+            template_key=item.get("template_key", ""),
+            status=item.get("status", ""),
+            from_email=item.get("from_email", ""),
+            idempotency_key=item.get("idempotency_key", ""),
+            created_at=item.get("created_at", ""),
+            raw=item,
+        )
+
+    @classmethod
+    def _detail_to_message(cls, item: dict) -> InboxMessage:
+        message = cls._summary_to_message(item, item.get("email", ""))
+        message.html_body = item.get("html_body", "") or ""
+        message.text_body = item.get("text_body", "") or ""
+        message.context = item.get("context") or {}
+        message.metadata = item.get("metadata") or {}
+        return message
+
+
+class RealInboxClient(InboxBackend):
+    """Stub for the real SES-inbound round-trip backend.
+
+    TODO(issue #194 / branch ``issue-194-ses-inbound``): implement against the
+    real inbound-capture read API once its contract is finalised. Until then
+    this client reports itself unconfigured so the one or two tests that select
+    it skip/xfail cleanly instead of blocking the suite. The constructor mirrors
+    :class:`MockInboxClient` so the swap is a one-liner once the contract lands.
+    """
+
+    name = "real"
+
     def __init__(
         self,
         base_url: str | None,
@@ -60,65 +346,25 @@ class MockInboxClient:
 
     @property
     def configured(self) -> bool:
-        return bool(self.base_url)
+        # Intentionally always False until E2E_REAL_INBOX_* + the read contract
+        # exist. Flip this to ``bool(self.base_url and self.api_key)`` and fill
+        # in the methods below once issue-194-ses-inbound ships.
+        return False
 
-    def _headers(self) -> dict:
-        headers = {"Accept": "application/json"}
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-        return headers
-
-    def list_messages(self, address: str) -> list[InboxMessage]:
-        if not self.configured:
-            raise MockInboxNotConfigured(
-                "E2E_MOCK_INBOX_URL is not set; the Datamailer mock inbox "
-                "endpoint is not available yet (see issue #194)."
-            )
-        resp = requests.get(
-            f"{self.base_url}/messages",
-            params={"address": address},
-            headers=self._headers(),
-            timeout=self.timeout,
+    def _not_ready(self):
+        raise InboxNotConfigured(
+            "Real SES-inbound inbox backend is not implemented yet "
+            "(issue #194, branch issue-194-ses-inbound). Set E2E_REAL_INBOX_URL "
+            "/ E2E_REAL_INBOX_API_KEY and implement RealInboxClient once the "
+            "read contract is finalised."
         )
-        resp.raise_for_status()
-        payload = resp.json()
-        items = payload.get("messages", payload if isinstance(payload, list) else [])
-        return [
-            InboxMessage(
-                to=item.get("to", address),
-                subject=item.get("subject", ""),
-                html=item.get("html", ""),
-                text=item.get("text", ""),
-                raw=item,
-            )
-            for item in items
-        ]
 
-    def wait_for_message(
-        self,
-        address: str,
-        *,
-        subject: str | None = None,
-        body_contains: str | None = None,
-        timeout: float = 60.0,
-        poll_interval: float = 3.0,
-    ) -> InboxMessage:
-        """Poll until a matching message arrives or ``timeout`` elapses."""
-        deadline = time.monotonic() + timeout
-        last_seen: list[InboxMessage] = []
-        while time.monotonic() < deadline:
-            last_seen = self.list_messages(address)
-            for message in last_seen:
-                if subject and subject not in message.subject:
-                    continue
-                if body_contains and not message.body_contains(body_contains):
-                    continue
-                return message
-            time.sleep(poll_interval)
+    def list_messages(self, address: str, *, limit: int = 25) -> list[InboxMessage]:
+        self._not_ready()
 
-        subjects = [m.subject for m in last_seen]
-        raise MockInboxTimeout(
-            f"No email to {address} matching subject={subject!r} / "
-            f"body~={body_contains!r} arrived within {timeout}s. "
-            f"Seen subjects: {subjects}"
-        )
+    def get_message(self, message_id) -> InboxMessage:
+        self._not_ready()
+
+    def clear(self, address: str | None = None) -> int:
+        # Safe no-op so teardown never fails on the unconfigured real backend.
+        return 0

--- a/e2e/provisioning.py
+++ b/e2e/provisioning.py
@@ -1,28 +1,34 @@
-"""Course-lifecycle provisioning and teardown via the REST API.
+"""Course-lifecycle provisioning and teardown.
+
+Provisioning and the deletable-object pre-pass go through the REST API (fast,
+token-auth). The **course itself is deleted through the Django admin UI**
+(driven by Playwright), not via a REST endpoint.
 
 Design notes on teardown (important):
 
 The CMP API is intentionally read-only for submissions, enrollments, answers
-and peer reviews, and there is no course DELETE endpoint. So full teardown of
-a run that has created submissions is **not possible through remote tooling
-alone**:
+and peer reviews, and there is deliberately **no course DELETE API endpoint**:
+a standing remote delete capability could let any API client/agent wipe too
+much data. Admin-panel deletion is instead gated behind an interactive staff
+login plus the admin's own confirmation screen, which is the safer path.
 
-* Homework / project objects can be DELETEd only when CLOSED and with zero
-  submissions.
-* Project submissions CAN be removed via the student UI (action=delete), so
-  a project can be brought back to a deletable state.
-* Homework submissions cannot be removed by any remote caller, so a homework
-  that has been submitted to cannot be deleted. The course shell itself
-  cannot be deleted either.
+Deleting a ``Course`` through the admin cascades to ALL of its data --
+Homework, Question, Project, Submission, Answer, ProjectSubmission,
+Enrollment, PeerReview are all ``on_delete=CASCADE`` from Course/Project -- so
+one admin delete of the course fully cleans a run.
 
 The teardown therefore:
-  1. Deletes every deletable object (closed homeworks/projects with no
-     submissions) in dependency order.
-  2. Parks the residual course (rename + ``visible=false`` + ``finished``)
-     so dev stays clean to anyone browsing.
-  3. Reports the residual so the post-run "clean" assertion can xfail with a
-     TODO pointing at #194 (needs an admin/API delete path), mirroring the
-     email-verification stub.
+  1. (Best-effort, optional) deletes individual deletable objects via the API
+     in dependency order -- harmless even though the admin delete supersedes
+     it; keeps the report informative.
+  2. Deletes the course through the admin UI (``admin_session``), which
+     cascades away every remaining row.
+  3. Falls back to *parking* the course (rename + ``visible=false`` +
+     ``finished``) only if the admin delete is unavailable or fails, so dev
+     still stays clean to anyone browsing, and reports the residual.
+
+When the admin delete succeeds there is no residual and the course is fully
+purged.
 """
 
 from __future__ import annotations
@@ -152,10 +158,16 @@ class Provisioner:
             self.api.update_project(course.slug, proj["id"], {"state": "CS"})
 
     # -- teardown --------------------------------------------------------
-    def teardown_course(self, slug: str) -> dict:
+    def teardown_course(self, slug: str, admin_session=None) -> dict:
         """Best-effort teardown of a single namespaced course.
 
-        Returns a residual report: ``{"deleted": [...], "residual": [...]}``.
+        The course (and its full cascade) is deleted through the Django admin
+        UI when an authenticated ``admin_session`` is supplied. If no session
+        is given, or the admin delete fails, the course is *parked hidden* as
+        a fallback so dev stays clean and the residual is reported.
+
+        Returns a residual report:
+        ``{"deleted": [...], "residual": [...], "course": slug}``.
         Never raises -- teardown must be robust even on partial failures.
         """
         deleted: list[str] = []
@@ -165,9 +177,11 @@ class Provisioner:
         if detail is None:
             return {"deleted": deleted, "residual": residual, "course": slug}
 
-        # Projects: close, then try delete. Submissions block deletion; the
-        # caller is expected to have already removed project submissions via
-        # the UI where possible.
+        title = detail.get("title") if isinstance(detail, dict) else None
+
+        # Best-effort API pre-pass on individually-deletable objects. This is
+        # informative for the report; the admin delete below supersedes it by
+        # cascading everything away regardless.
         for proj in self.api.list_projects(slug):
             _close_and_delete(
                 lambda pid: self.api.update_project(slug, pid, {"state": "CL"}),
@@ -178,7 +192,6 @@ class Provisioner:
                 residual=residual,
             )
 
-        # Homeworks: close, then try delete.
         for hw in self.api.list_homeworks(slug):
             _close_and_delete(
                 lambda hid: self.api.update_homework(slug, hid, {"state": "CL"}),
@@ -189,7 +202,24 @@ class Provisioner:
                 residual=residual,
             )
 
-        # Park the course (cannot be deleted via API).
+        # Primary path: delete the course (and its cascade) via the admin UI.
+        if admin_session is not None:
+            try:
+                purged = admin_session.delete_course_via_admin(slug, title=title)
+            except Exception:
+                purged = False
+            if purged:
+                deleted.append(f"course:{slug} (admin-deleted, cascaded)")
+                return {"deleted": deleted, "residual": residual, "course": slug}
+            residual.append(
+                f"course:{slug} (admin delete failed; parked hidden)"
+            )
+        else:
+            residual.append(
+                f"course:{slug} (no admin session; parked hidden)"
+            )
+
+        # Fallback: park the course hidden so dev stays clean.
         try:
             self.api.update_course(
                 slug,
@@ -201,17 +231,20 @@ class Provisioner:
             )
         except ApiError:
             pass
-        residual.append(f"course:{slug} (no delete endpoint; parked hidden)")
 
         return {"deleted": deleted, "residual": residual, "course": slug}
 
-    def sweep_stale(self) -> list[dict]:
-        """Pre-run sweep: tear down any leftover ``e2e-smoke-*`` courses."""
+    def sweep_stale(self, admin_session=None) -> list[dict]:
+        """Pre-run sweep: tear down any leftover ``e2e-smoke-*`` courses.
+
+        Uses admin-UI deletion (cascade) when an ``admin_session`` is given,
+        otherwise falls back to parking each stale course hidden.
+        """
         reports = []
         for course in self.api.list_courses():
             slug = course.get("slug", "")
             if slug.startswith(NAMESPACE_PREFIX):
-                reports.append(self.teardown_course(slug))
+                reports.append(self.teardown_course(slug, admin_session=admin_session))
         return reports
 
     def list_active_namespaced_courses(self) -> list[str]:

--- a/e2e/provisioning.py
+++ b/e2e/provisioning.py
@@ -1,0 +1,248 @@
+"""Course-lifecycle provisioning and teardown via the REST API.
+
+Design notes on teardown (important):
+
+The CMP API is intentionally read-only for submissions, enrollments, answers
+and peer reviews, and there is no course DELETE endpoint. So full teardown of
+a run that has created submissions is **not possible through remote tooling
+alone**:
+
+* Homework / project objects can be DELETEd only when CLOSED and with zero
+  submissions.
+* Project submissions CAN be removed via the student UI (action=delete), so
+  a project can be brought back to a deletable state.
+* Homework submissions cannot be removed by any remote caller, so a homework
+  that has been submitted to cannot be deleted. The course shell itself
+  cannot be deleted either.
+
+The teardown therefore:
+  1. Deletes every deletable object (closed homeworks/projects with no
+     submissions) in dependency order.
+  2. Parks the residual course (rename + ``visible=false`` + ``finished``)
+     so dev stays clean to anyone browsing.
+  3. Reports the residual so the post-run "clean" assertion can xfail with a
+     TODO pointing at #194 (needs an admin/API delete path), mirroring the
+     email-verification stub.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+from .api_client import ApiError, CmpApiClient
+from .config import NAMESPACE_PREFIX
+
+
+@dataclass
+class ProvisionedCourse:
+    slug: str
+    title: str
+    homework_id: int | None = None
+    homework_slug: str | None = None
+    project_id: int | None = None
+    project_slug: str | None = None
+    question_ids: list[int] = field(default_factory=list)
+
+
+def make_namespace(timestamp: int | None = None) -> str:
+    ts = timestamp if timestamp is not None else int(time.time())
+    return f"{NAMESPACE_PREFIX}{ts}"
+
+
+# Question payloads exercising all three required types (FF, CB, MC) plus a
+# long free-form, so the homework form renders text inputs, checkboxes and
+# radios for the browser flow.
+def default_questions() -> list[dict]:
+    return [
+        {
+            "text": "What is the capital of France? (free form)",
+            "question_type": "FF",
+            "answer_type": "EXS",
+            "correct_answer": "Paris",
+            "scores_for_correct_answer": 1,
+        },
+        {
+            "text": "Pick the even numbers (checkboxes)",
+            "question_type": "CB",
+            "answer_type": "ANY",
+            "possible_answers": ["1", "2", "3", "4"],
+            # 1-based indices of the correct options (2 and 4).
+            "correct_answer": "2,4",
+            "scores_for_correct_answer": 1,
+        },
+        {
+            "text": "What is 2 + 2? (multiple choice)",
+            "question_type": "MC",
+            "answer_type": "INT",
+            "possible_answers": ["3", "4", "5"],
+            # 1-based index of the correct option ("4").
+            "correct_answer": "2",
+            "scores_for_correct_answer": 1,
+        },
+        {
+            "text": "Describe what you learned (long free form)",
+            "question_type": "FL",
+            "answer_type": "ANY",
+            "correct_answer": "",
+            "scores_for_correct_answer": 0,
+        },
+    ]
+
+
+class Provisioner:
+    def __init__(self, api: CmpApiClient):
+        self.api = api
+
+    # -- create ----------------------------------------------------------
+    def create_course(self, namespace: str) -> ProvisionedCourse:
+        course = self.api.create_course(
+            {
+                "slug": namespace,
+                "title": f"E2E Smoke {namespace}",
+                "description": "Automated e2e smoke-test course. Safe to delete.",
+                "visible": True,
+            }
+        )
+        return ProvisionedCourse(slug=course["slug"], title=course["title"])
+
+    def add_homework(
+        self, course: ProvisionedCourse, *, due_date: str, open_now: bool = True
+    ) -> None:
+        hw = self.api.create_homework(
+            course.slug,
+            {
+                "name": "E2E Homework 1",
+                "slug": "hw-1",
+                "due_date": due_date,
+                "description": "Smoke-test homework.",
+                "learning_in_public_cap": 2,
+                "homework_url_field": True,
+                "time_spent_lectures_field": True,
+                "time_spent_homework_field": True,
+                "questions": default_questions(),
+            },
+        )
+        course.homework_id = hw["id"]
+        course.homework_slug = hw["slug"]
+        if open_now:
+            self.api.update_homework(course.slug, hw["id"], {"state": "OP"})
+
+    def add_project(
+        self,
+        course: ProvisionedCourse,
+        *,
+        submission_due_date: str,
+        peer_review_due_date: str,
+        collecting: bool = True,
+    ) -> None:
+        proj = self.api.create_project(
+            course.slug,
+            {
+                "name": "E2E Project 1",
+                "slug": "project-1",
+                "submission_due_date": submission_due_date,
+                "peer_review_due_date": peer_review_due_date,
+                "description": "Smoke-test project.",
+            },
+        )
+        course.project_id = proj["id"]
+        course.project_slug = proj["slug"]
+        if collecting:
+            self.api.update_project(course.slug, proj["id"], {"state": "CS"})
+
+    # -- teardown --------------------------------------------------------
+    def teardown_course(self, slug: str) -> dict:
+        """Best-effort teardown of a single namespaced course.
+
+        Returns a residual report: ``{"deleted": [...], "residual": [...]}``.
+        Never raises -- teardown must be robust even on partial failures.
+        """
+        deleted: list[str] = []
+        residual: list[str] = []
+
+        detail = self.api.get_course(slug)
+        if detail is None:
+            return {"deleted": deleted, "residual": residual, "course": slug}
+
+        # Projects: close, then try delete. Submissions block deletion; the
+        # caller is expected to have already removed project submissions via
+        # the UI where possible.
+        for proj in self.api.list_projects(slug):
+            _close_and_delete(
+                lambda pid: self.api.update_project(slug, pid, {"state": "CL"}),
+                lambda pid: self.api.delete_project(slug, pid),
+                proj,
+                kind="project",
+                deleted=deleted,
+                residual=residual,
+            )
+
+        # Homeworks: close, then try delete.
+        for hw in self.api.list_homeworks(slug):
+            _close_and_delete(
+                lambda hid: self.api.update_homework(slug, hid, {"state": "CL"}),
+                lambda hid: self.api.delete_homework(slug, hid),
+                hw,
+                kind="homework",
+                deleted=deleted,
+                residual=residual,
+            )
+
+        # Park the course (cannot be deleted via API).
+        try:
+            self.api.update_course(
+                slug,
+                {
+                    "title": f"[DELETED] {slug}",
+                    "visible": False,
+                    "finished": True,
+                },
+            )
+        except ApiError:
+            pass
+        residual.append(f"course:{slug} (no delete endpoint; parked hidden)")
+
+        return {"deleted": deleted, "residual": residual, "course": slug}
+
+    def sweep_stale(self) -> list[dict]:
+        """Pre-run sweep: tear down any leftover ``e2e-smoke-*`` courses."""
+        reports = []
+        for course in self.api.list_courses():
+            slug = course.get("slug", "")
+            if slug.startswith(NAMESPACE_PREFIX):
+                reports.append(self.teardown_course(slug))
+        return reports
+
+    def list_active_namespaced_courses(self) -> list[str]:
+        """Courses still visible under our namespace (for the clean assert)."""
+        return [
+            c["slug"]
+            for c in self.api.list_courses()
+            if c.get("slug", "").startswith(NAMESPACE_PREFIX)
+            and c.get("visible", True)
+        ]
+
+
+def _close_and_delete(close_fn, delete_fn, obj, *, kind, deleted, residual):
+    obj_id = obj.get("id")
+    label = f"{kind}:{obj.get('slug', obj_id)}"
+    try:
+        close_fn(obj_id)
+    except ApiError:
+        pass
+    try:
+        resp = delete_fn(obj_id)
+    except ApiError:
+        residual.append(f"{label} (delete errored)")
+        return
+    if resp.status_code in (200, 404):
+        deleted.append(label)
+    else:
+        # 400 -> blocked, typically by existing submissions.
+        body = ""
+        try:
+            body = resp.json().get("error", "")
+        except ValueError:
+            body = resp.text[:120]
+        residual.append(f"{label} (blocked: {body})")

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -17,3 +17,4 @@ markers =
     dashboards: dashboards and statistics pages
     teardown: cleanup and clean-state assertions
     email: Datamailer email verification (depends on mock inbox, may xfail)
+    real_inbox: email check that uses the real SES-inbound backend (xfail/skip until #194 ses-inbound lands)

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,0 +1,19 @@
+[pytest]
+# Standalone pytest config for the live e2e smoke suite. It deliberately does
+# NOT set DJANGO_SETTINGS_MODULE: these tests hit a remote server and must not
+# bootstrap Django or the project DB. Run from the repo root with:
+#   uv run pytest -c e2e/pytest.ini
+testpaths = tests
+python_files = test_*.py
+# Disable pytest-django for this suite: it talks to a live server and must
+# not bootstrap Django. -p no:cacheprovider keeps the repo tree untouched.
+addopts = -ra -v --strict-markers -p no:django
+markers =
+    smoke: core availability/auth smoke checks (run first, fail fast)
+    provisioning: API course/content provisioning
+    enrollment: enrollment and identity
+    homework: homework submission + scoring + leaderboard flow
+    project: project submission + peer review + scoring flow
+    dashboards: dashboards and statistics pages
+    teardown: cleanup and clean-state assertions
+    email: Datamailer email verification (depends on mock inbox, may xfail)

--- a/e2e/tests/test_00_availability.py
+++ b/e2e/tests/test_00_availability.py
@@ -1,0 +1,59 @@
+"""Scenario 1 (issue #194): Availability & auth.
+
+* GET /api/health/ returns {status: ok} (+ expected version when configured).
+* Admin login page loads and admin can authenticate via the login form.
+* Unauthenticated access to a protected page redirects to login.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def test_health_endpoint_ok(api, settings):
+    body = api.health()
+    assert body.get("status") == "ok", f"Health not ok: {body}"
+    assert "version" in body, f"Health response missing version: {body}"
+    if settings.expected_version:
+        assert body["version"] == settings.expected_version, (
+            f"Deployed version {body['version']!r} != expected "
+            f"{settings.expected_version!r} -- did the deploy finish?"
+        )
+
+
+def test_admin_login_page_loads(admin_page, settings):
+    admin_page.goto(f"{settings.base_url}/admin/login/")
+    assert admin_page.locator("input[name='username']").count() == 1, (
+        "Admin login form (input[name=username]) did not render."
+    )
+    assert admin_page.locator("input[name='password']").count() == 1
+
+
+def test_admin_can_authenticate(admin_session, settings):
+    # admin_session fixture already logged in via the admin form; confirm the
+    # session is authenticated.
+    admin_session.page.goto(f"{settings.base_url}/admin/")
+    assert "/admin/login" not in admin_session.page.url, (
+        "Admin session not authenticated after login."
+    )
+
+
+def test_protected_page_redirects_to_login(admin_page, settings):
+    # account settings requires login; from a fresh (unauthenticated) context
+    # we expect a redirect to a login page. Use a throwaway context so this is
+    # independent of the admin_session login order.
+    ctx = admin_page.context.browser.new_context(base_url=settings.base_url)
+    page = ctx.new_page()
+    try:
+        page.goto(f"{settings.base_url}/accounts/settings/")
+        # The platform redirects unauthenticated users to its login page
+        # (LOGIN_URL is /login/) with a ?next= back to the protected page.
+        assert re.search(r"/login(/|\?|$)", page.url) and "next=" in page.url, (
+            f"Protected page did not redirect to login; landed on {page.url}"
+        )
+    finally:
+        ctx.close()

--- a/e2e/tests/test_01_provisioning.py
+++ b/e2e/tests/test_01_provisioning.py
@@ -10,9 +10,13 @@ import pytest
 pytestmark = pytest.mark.provisioning
 
 
-def test_pre_run_sweep_of_stale_data(provisioner):
-    """Remove leftovers from previous failed runs before provisioning."""
-    reports = provisioner.sweep_stale()
+def test_pre_run_sweep_of_stale_data(provisioner, optional_admin_session):
+    """Remove leftovers from previous failed runs before provisioning.
+
+    Deletes stale ``e2e-smoke-*`` courses through the admin UI (cascade) when
+    admin creds are configured; otherwise parks them hidden.
+    """
+    reports = provisioner.sweep_stale(admin_session=optional_admin_session)
     # Sweep is best-effort and must not fail the run; just surface what it did.
     for report in reports:
         print(

--- a/e2e/tests/test_01_provisioning.py
+++ b/e2e/tests/test_01_provisioning.py
@@ -1,0 +1,59 @@
+"""Scenario 2 (issue #194): Course & content provisioning (via API).
+
+Also performs the pre-run sweep of stale ``e2e-smoke-*`` data (scenario 8).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.provisioning
+
+
+def test_pre_run_sweep_of_stale_data(provisioner):
+    """Remove leftovers from previous failed runs before provisioning."""
+    reports = provisioner.sweep_stale()
+    # Sweep is best-effort and must not fail the run; just surface what it did.
+    for report in reports:
+        print(
+            f"[sweep] {report['course']}: "
+            f"deleted={report['deleted']} residual={report['residual']}"
+        )
+
+
+def test_create_course(provisioner, run_state):
+    run_state.course = provisioner.create_course(run_state.namespace)
+    assert run_state.course.slug == run_state.namespace
+    fetched = provisioner.api.get_course(run_state.namespace)
+    assert fetched is not None, "Course not retrievable after creation."
+    assert fetched["title"].startswith("E2E Smoke")
+
+
+def test_create_homework_with_all_question_types(
+    provisioner, run_state, due_dates
+):
+    assert run_state.course, "Course must be created first."
+    provisioner.add_homework(
+        run_state.course, due_date=due_dates["homework_due"], open_now=True
+    )
+    assert run_state.course.homework_id is not None
+
+    # Verify all three required question types are present.
+    hw = provisioner.api.list_homeworks(run_state.course.slug)[0]
+    assert hw["questions_count"] >= 3, (
+        f"Expected at least 3 questions, got {hw['questions_count']}"
+    )
+    assert hw["state"] == "OP", "Homework should be open for submissions."
+
+
+def test_create_project(provisioner, run_state, due_dates):
+    assert run_state.course, "Course must be created first."
+    provisioner.add_project(
+        run_state.course,
+        submission_due_date=due_dates["project_due"],
+        peer_review_due_date=due_dates["peer_review_due"],
+        collecting=True,
+    )
+    assert run_state.course.project_id is not None
+    proj = provisioner.api.list_projects(run_state.course.slug)[0]
+    assert proj["state"] == "CS", "Project should be collecting submissions."

--- a/e2e/tests/test_02_enrollment.py
+++ b/e2e/tests/test_02_enrollment.py
@@ -20,8 +20,10 @@ pytestmark = pytest.mark.enrollment
 def _student_email(settings, run_state) -> str:
     if settings.student_email:
         return settings.student_email
-    # Per-run, recognizable, and routed at the Datamailer mock address.
-    return f"{run_state.namespace}@inbox.dtcdev.click"
+    # Per-run, recognizable, and routed at the Datamailer *mock* address so the
+    # confirmation email is captured by the mock inbox (e2e+<namespace>@mailbox.test)
+    # instead of being delivered for real. Unique tag per run.
+    return settings.mock_address(run_state.namespace)
 
 
 def test_test_student_exists(admin_session, settings, run_state):

--- a/e2e/tests/test_02_enrollment.py
+++ b/e2e/tests/test_02_enrollment.py
@@ -1,0 +1,60 @@
+"""Scenario 3 (issue #194): Enrollment & identity.
+
+* A test student (admin-side, email at the Datamailer mock address) exists.
+* Admin impersonates the student (django-loginas -- no OAuth).
+* Student profile / settings page renders.
+
+Enrollment in this platform is auto-created on first homework/project
+submission (``Enrollment.objects.get_or_create``), so the explicit
+"enrollment exists" assertion is validated after the homework flow; here we
+establish identity + impersonation and confirm the profile renders.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.enrollment
+
+
+def _student_email(settings, run_state) -> str:
+    if settings.student_email:
+        return settings.student_email
+    # Per-run, recognizable, and routed at the Datamailer mock address.
+    return f"{run_state.namespace}@inbox.dtcdev.click"
+
+
+def test_test_student_exists(admin_session, settings, run_state):
+    # admin_session is authenticated by its fixture.
+    student_email = _student_email(settings, run_state)
+    student_password = settings.student_password or "E2eSmoke!" + run_state.namespace
+    run_state.student_email = student_email
+    run_state.student_user_id = admin_session.ensure_student(
+        student_email, student_password
+    )
+    assert run_state.student_user_id, "Could not create/find the test student."
+
+
+def test_impersonate_student(admin_session, run_state):
+    assert run_state.student_user_id, "Student must exist first."
+    admin_session.impersonate(run_state.student_user_id)
+    # Confirm we are now the student, not the admin: account settings renders
+    # for a logged-in (non-admin) user.
+    body = admin_session.open("/accounts/settings/")
+    assert "login" not in admin_session.page.url, (
+        "Impersonation failed: redirected to login on /accounts/settings/."
+    )
+    assert body, "Account settings page rendered empty."
+
+
+def test_student_profile_page_renders(admin_session, run_state):
+    assert run_state.student_user_id, "Student must exist first."
+    admin_session.open("/accounts/settings/")
+    # The settings page exposes the notification toggles; check one renders.
+    assert (
+        admin_session.page.locator(
+            "[name='email_submission_confirmations'], "
+            "form"
+        ).count()
+        > 0
+    ), "Student settings form did not render."

--- a/e2e/tests/test_03_homework.py
+++ b/e2e/tests/test_03_homework.py
@@ -1,0 +1,158 @@
+"""Scenario 4 (issue #194): Homework flow.
+
+* Submit homework answers through the UI (as impersonated student).
+* Confirmation page renders with the submitted values.
+* Submission-confirmation email received at the mock inbox (xfail until the
+  mock-inbox endpoint exists -- see #194).
+* Score the homework (API); submission shows a score.
+* Leaderboard reflects the score.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.homework
+
+
+@pytest.fixture(scope="module")
+def hw_answers():
+    # Keyed by question position; resolved to question ids in the test.
+    return {
+        "free_form": "Paris",
+        "checkboxes": "2,4",
+        "multiple_choice": "2",
+        "long_free_form": "I learned how to write e2e smoke tests.",
+    }
+
+
+def _questions_via_api(api, run_state, hw_id) -> dict[str, int]:
+    resp = api._request(  # internal helper reuse, read-only GET
+        "GET",
+        f"/api/courses/{run_state.course.slug}/homeworks/{hw_id}/questions/",
+        expected=(200,),
+    )
+    questions = resp.json().get("questions", [])
+    mapping: dict[str, int] = {}
+    for q in questions:
+        text = q.get("text", "").lower()
+        if "free form)" in text and "long" not in text:
+            mapping["free_form"] = q["id"]
+        elif "checkboxes" in text:
+            mapping["checkboxes"] = q["id"]
+        elif "multiple choice" in text:
+            mapping["multiple_choice"] = q["id"]
+        elif "long free form" in text:
+            mapping["long_free_form"] = q["id"]
+    return mapping
+
+
+def test_submit_homework_via_ui(admin_session, api, run_state, hw_answers):
+    assert run_state.student_user_id, "Student/impersonation required first."
+    assert run_state.course and run_state.course.homework_slug
+
+    qmap = _questions_via_api(api, run_state, run_state.course.homework_id)
+    assert {"free_form", "checkboxes", "multiple_choice"} <= set(qmap), (
+        f"Could not resolve all question ids: {qmap}"
+    )
+
+    answers = {
+        qmap["free_form"]: hw_answers["free_form"],
+        qmap["checkboxes"]: hw_answers["checkboxes"],
+        qmap["multiple_choice"]: hw_answers["multiple_choice"],
+    }
+    if "long_free_form" in qmap:
+        answers[qmap["long_free_form"]] = hw_answers["long_free_form"]
+
+    admin_session.submit_homework(
+        run_state.course.slug,
+        run_state.course.homework_slug,
+        answers,
+        homework_url="https://github.com/example/e2e-homework",
+        learning_in_public_links=[
+            f"https://twitter.com/e2e/{run_state.namespace}-hw"
+        ],
+        time_spent_lectures=2,
+        time_spent_homework=3,
+    )
+    run_state.homework_submitted = True
+
+    body = admin_session.homework_confirmation_text()
+    assert "Thank you for submitting your homework" in body, (
+        "Homework confirmation message not shown after submission."
+    )
+
+
+def test_homework_submission_recorded_in_api(api, run_state):
+    require_submitted(run_state)
+    data = api.homework_submissions(
+        run_state.course.slug, run_state.course.homework_slug
+    )
+    submissions = data.get("submissions", [])
+    assert any(
+        s.get("student", {}).get("email") == run_state.student_email
+        or run_state.student_email in str(s)
+        for s in submissions
+    ), f"No submission found for {run_state.student_email}: {submissions!r}"
+
+
+@pytest.mark.email
+def test_homework_confirmation_email(mock_inbox, run_state):
+    require_submitted(run_state)
+    if not mock_inbox.configured:
+        pytest.xfail(
+            "Datamailer mock inbox endpoint not available yet "
+            "(E2E_MOCK_INBOX_URL unset). TODO: enable once #194 sub-task lands."
+        )
+    message = mock_inbox.wait_for_message(
+        run_state.student_email,
+        subject="Homework submission saved",
+        timeout=90,
+    )
+    assert "E2E Homework 1" in message.subject
+    # Confirmation email carries an "Update your submission" link.
+    assert message.body_contains("/homework/"), (
+        "Homework confirmation email missing update link."
+    )
+
+
+def test_score_homework(api, run_state):
+    require_submitted(run_state)
+    result = api.score_homework(
+        run_state.course.slug, run_state.course.homework_id
+    )
+    assert result.get("status") == "OK", f"Scoring failed: {result}"
+
+    data = api.homework_submissions(
+        run_state.course.slug, run_state.course.homework_slug
+    )
+    submissions = data.get("submissions", [])
+    assert submissions, "No submissions to score."
+    # At least one submission now has a numeric score.
+    assert any(
+        _has_score(s) for s in submissions
+    ), f"No scored submission after scoring: {submissions!r}"
+
+
+def test_leaderboard_reflects_score(api, run_state):
+    require_submitted(run_state)
+    leaderboard = api.leaderboard_yaml(run_state.course.slug)
+    # The student appears on the leaderboard once the first homework is scored.
+    assert leaderboard.strip(), "Leaderboard is empty after scoring."
+
+
+def _has_score(submission: dict) -> bool:
+    for key in ("total_score", "questions_score", "score"):
+        value = submission.get(key)
+        if isinstance(value, (int, float)) and value is not None:
+            return True
+    # Nested under a homework_submission object in some exports.
+    nested = submission.get("homework_submission") or {}
+    return any(
+        isinstance(nested.get(k), (int, float)) for k in ("total_score", "score")
+    )
+
+
+def require_submitted(run_state):
+    if not run_state.homework_submitted:
+        pytest.skip("Homework was not submitted (earlier step skipped/failed).")

--- a/e2e/tests/test_03_homework.py
+++ b/e2e/tests/test_03_homework.py
@@ -96,24 +96,66 @@ def test_homework_submission_recorded_in_api(api, run_state):
     ), f"No submission found for {run_state.student_email}: {submissions!r}"
 
 
-@pytest.mark.email
-def test_homework_confirmation_email(mock_inbox, run_state):
-    require_submitted(run_state)
-    if not mock_inbox.configured:
-        pytest.xfail(
-            "Datamailer mock inbox endpoint not available yet "
-            "(E2E_MOCK_INBOX_URL unset). TODO: enable once #194 sub-task lands."
-        )
-    message = mock_inbox.wait_for_message(
+# Confirmation-email contract (from courses/views/homework.py, read-only):
+#   template_key = "homework-submission-confirmation"
+#   subject      = "Homework submission saved: <homework title>"
+#   context      = {update_url, profile_url, course_slug, homework_slug, ...}
+HOMEWORK_CONFIRMATION_TEMPLATE = "homework-submission-confirmation"
+
+
+def _assert_homework_confirmation(backend, run_state):
+    message = backend.wait_for_message(
         run_state.student_email,
+        template_key=HOMEWORK_CONFIRMATION_TEMPLATE,
         subject="Homework submission saved",
         timeout=90,
     )
+    assert message.template_key == HOMEWORK_CONFIRMATION_TEMPLATE
     assert "E2E Homework 1" in message.subject
-    # Confirmation email carries an "Update your submission" link.
+    # The confirmation carries an "Update your submission" link; the homework
+    # update URL lives in context.update_url and the rendered body.
     assert message.body_contains("/homework/"), (
-        "Homework confirmation email missing update link."
+        "Homework confirmation email missing update link "
+        f"(context keys: {sorted(message.context)})."
     )
+
+
+@pytest.mark.email
+def test_homework_confirmation_email(mock_inbox, run_state):
+    """Primary path: assert via the fast mock-store backend (default)."""
+    require_submitted(run_state)
+    if not mock_inbox.configured:
+        pytest.xfail(
+            "Datamailer mock inbox not configured (E2E_MOCK_INBOX_URL / "
+            "DATAMAILER_URL unset). TODO: enable once #194 mock-inbox is "
+            "deployed to dev and creds are provided."
+        )
+    try:
+        _assert_homework_confirmation(mock_inbox, run_state)
+    finally:
+        # Teardown: clear this run's captured messages for the mock address.
+        mock_inbox.clear(run_state.student_email)
+
+
+@pytest.mark.email
+@pytest.mark.real_inbox
+def test_homework_confirmation_email_real_ses(email_backend, run_state):
+    """Dedicated real-SES round-trip check (one of the 1-2 real-backend tests).
+
+    Uses the ``real`` backend via the ``email_backend`` selector. xfails until
+    the SES-inbound capture API (issue #194, branch issue-194-ses-inbound) and
+    E2E_REAL_INBOX_* config exist.
+    """
+    require_submitted(run_state)
+    if not email_backend.configured:
+        pytest.xfail(
+            "Real SES-inbound inbox backend not ready "
+            "(issue #194 / issue-194-ses-inbound; E2E_REAL_INBOX_* unset)."
+        )
+    try:
+        _assert_homework_confirmation(email_backend, run_state)
+    finally:
+        email_backend.clear(run_state.student_email)
 
 
 def test_score_homework(api, run_state):

--- a/e2e/tests/test_04_project.py
+++ b/e2e/tests/test_04_project.py
@@ -1,0 +1,117 @@
+"""Scenario 5 (issue #194): Project flow.
+
+* Submit a project through the UI (as impersonated student).
+* Submission-confirmation email received (xfail until mock inbox lands).
+* Assign peer reviews (API).
+* Score the project; verify score components.
+* Leaderboard + project statistics update.
+
+Note: meaningful peer-review assignment needs >= 2 submitters. A single-
+student smoke run exercises the assign/score endpoints and asserts they
+succeed and return sane counts, rather than requiring assigned reviews.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.project
+
+
+def test_submit_project_via_ui(admin_session, run_state):
+    assert run_state.student_user_id, "Student/impersonation required first."
+    assert run_state.course and run_state.course.project_slug
+
+    admin_session.submit_project(
+        run_state.course.slug,
+        run_state.course.project_slug,
+        github_link="https://github.com/example/e2e-project",
+        commit_id="abc1234",
+        certificate_name="E2E Smoke Student",
+        time_spent=5,
+        learning_in_public_links=[
+            f"https://twitter.com/e2e/{run_state.namespace}-proj"
+        ],
+    )
+    run_state.project_submitted = True
+
+    body = admin_session.page.locator("body").inner_text()
+    assert "Thank you for submitting your project" in body, (
+        "Project confirmation message not shown after submission."
+    )
+
+
+def test_project_submission_recorded_in_api(api, run_state):
+    require_project(run_state)
+    data = api.project_submissions(
+        run_state.course.slug, run_state.course.project_slug
+    )
+    submissions = data.get("submissions", [])
+    assert any(
+        run_state.student_email in str(s) for s in submissions
+    ), f"No project submission for {run_state.student_email}: {submissions!r}"
+
+
+@pytest.mark.email
+def test_project_confirmation_email(mock_inbox, run_state):
+    require_project(run_state)
+    if not mock_inbox.configured:
+        pytest.xfail(
+            "Datamailer mock inbox endpoint not available yet "
+            "(E2E_MOCK_INBOX_URL unset). TODO: enable once #194 sub-task lands."
+        )
+    message = mock_inbox.wait_for_message(
+        run_state.student_email,
+        subject="Project submission saved",
+        timeout=90,
+    )
+    assert "E2E Project 1" in message.subject
+    assert message.body_contains("/project/"), (
+        "Project confirmation email missing update link."
+    )
+
+
+def test_assign_peer_reviews(api, run_state):
+    require_project(run_state)
+    # Move project into peer-reviewing before assigning.
+    api.update_project(
+        run_state.course.slug, run_state.course.project_id, {"state": "PR"}
+    )
+    result = api.assign_project_reviews(
+        run_state.course.slug, run_state.course.project_id
+    )
+    # OK with 0 assigned is acceptable for a single-submitter smoke run; the
+    # important thing is the endpoint runs without error.
+    assert "status" in result, f"assign-reviews returned no status: {result}"
+    assert result.get("status") in ("OK", "ERROR"), result
+
+
+def test_score_project(api, run_state):
+    require_project(run_state)
+    result = api.score_project(
+        run_state.course.slug, run_state.course.project_id
+    )
+    assert "status" in result, f"score returned no status: {result}"
+    # Verify the score-component fields exist in the submissions export.
+    data = api.project_submissions(
+        run_state.course.slug, run_state.course.project_slug
+    )
+    submissions = data.get("submissions", [])
+    assert submissions, "No project submissions to score."
+    sample = str(submissions[0]).lower()
+    # The export documents project/faq/learning-in-public/peer-review scores.
+    assert any(
+        token in sample
+        for token in ("score", "peer", "passed")
+    ), f"Score components not present in submission export: {submissions[0]!r}"
+
+
+def test_leaderboard_and_project_stats_update(api, run_state):
+    require_project(run_state)
+    leaderboard = api.leaderboard_yaml(run_state.course.slug)
+    assert leaderboard.strip(), "Leaderboard empty after project scoring."
+
+
+def require_project(run_state):
+    if not run_state.project_submitted:
+        pytest.skip("Project was not submitted (earlier step skipped/failed).")

--- a/e2e/tests/test_04_project.py
+++ b/e2e/tests/test_04_project.py
@@ -52,23 +52,38 @@ def test_project_submission_recorded_in_api(api, run_state):
     ), f"No project submission for {run_state.student_email}: {submissions!r}"
 
 
+# Confirmation-email contract (from courses/views/project.py, read-only):
+#   template_key = "project-submission-confirmation"
+#   subject      = "Project submission saved: <project title>"
+#   context      = {update_url, profile_url, course_slug, project_slug, ...}
+PROJECT_CONFIRMATION_TEMPLATE = "project-submission-confirmation"
+
+
 @pytest.mark.email
 def test_project_confirmation_email(mock_inbox, run_state):
+    """Assert via the fast mock-store backend (default)."""
     require_project(run_state)
     if not mock_inbox.configured:
         pytest.xfail(
-            "Datamailer mock inbox endpoint not available yet "
-            "(E2E_MOCK_INBOX_URL unset). TODO: enable once #194 sub-task lands."
+            "Datamailer mock inbox not configured (E2E_MOCK_INBOX_URL / "
+            "DATAMAILER_URL unset). TODO: enable once #194 mock-inbox is "
+            "deployed to dev and creds are provided."
         )
-    message = mock_inbox.wait_for_message(
-        run_state.student_email,
-        subject="Project submission saved",
-        timeout=90,
-    )
-    assert "E2E Project 1" in message.subject
-    assert message.body_contains("/project/"), (
-        "Project confirmation email missing update link."
-    )
+    try:
+        message = mock_inbox.wait_for_message(
+            run_state.student_email,
+            template_key=PROJECT_CONFIRMATION_TEMPLATE,
+            subject="Project submission saved",
+            timeout=90,
+        )
+        assert message.template_key == PROJECT_CONFIRMATION_TEMPLATE
+        assert "E2E Project 1" in message.subject
+        assert message.body_contains("/project/"), (
+            "Project confirmation email missing update link "
+            f"(context keys: {sorted(message.context)})."
+        )
+    finally:
+        mock_inbox.clear(run_state.student_email)
 
 
 def test_assign_peer_reviews(api, run_state):

--- a/e2e/tests/test_05_dashboards.py
+++ b/e2e/tests/test_05_dashboards.py
@@ -1,0 +1,53 @@
+"""Scenario 7 (issue #194): Dashboards & statistics pages render.
+
+These pages are rendered HTML, so we drive them through the browser (still
+authenticated from the admin session) and assert they return 200 with the
+provisioned course present, rather than 500/empty.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.dashboards
+
+
+def test_course_page_renders(admin_session, run_state):
+    assert run_state.course, "Course required."
+    admin_session.page.goto(
+        f"{admin_session.base_url}/{run_state.course.slug}/"
+    )
+    admin_session.page.wait_for_load_state("networkidle")
+    assert admin_session.page.url.rstrip("/").endswith(run_state.course.slug)
+    body = admin_session.page.locator("body").inner_text()
+    assert run_state.course.title in body or "E2E Smoke" in body, (
+        "Course page did not render the provisioned course title."
+    )
+
+
+def test_dashboard_renders(admin_session, run_state):
+    assert run_state.course, "Course required."
+    resp = admin_session.page.goto(
+        f"{admin_session.base_url}/{run_state.course.slug}/dashboard"
+    )
+    admin_session.page.wait_for_load_state("networkidle")
+    assert resp is None or resp.status < 500, (
+        f"Dashboard returned server error: "
+        f"{resp.status if resp else 'unknown'}"
+    )
+    body = admin_session.page.locator("body").inner_text()
+    assert body.strip(), "Dashboard rendered empty."
+
+
+def test_leaderboard_renders(admin_session, run_state):
+    assert run_state.course, "Course required."
+    resp = admin_session.page.goto(
+        f"{admin_session.base_url}/{run_state.course.slug}/leaderboard"
+    )
+    admin_session.page.wait_for_load_state("networkidle")
+    assert resp is None or resp.status < 500, (
+        f"Leaderboard returned server error: "
+        f"{resp.status if resp else 'unknown'}"
+    )
+    body = admin_session.page.locator("body").inner_text()
+    assert body.strip(), "Leaderboard rendered empty."

--- a/e2e/tests/test_06_mock_inbox_client.py
+++ b/e2e/tests/test_06_mock_inbox_client.py
@@ -1,0 +1,266 @@
+"""Unit-level tests for the email-verification clients (no network).
+
+These exercise :class:`MockInboxClient` against a fake requests session, so they
+run anywhere (CI, local) without the mock inbox being deployed. They lock down
+the wire contract the client targets (paths, params, auth header, response
+shapes, poll/timeout/clear behaviour). The *live* email assertions
+(``test_03/04``) still need the mock inbox deployed to dev + creds.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+
+from e2e.config import Settings, load_settings
+from e2e.mock_inbox import (
+    InboxDisabled,
+    InboxNotConfigured,
+    MockInboxClient,
+    MockInboxTimeout,
+    RealInboxClient,
+)
+
+pytestmark = pytest.mark.email
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code}")
+
+
+class FakeSession:
+    """Records requests and replays a scripted list of responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        result = self._responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _client(responses):
+    client = MockInboxClient("https://datamailer.example", "k-secret")
+    client._session = FakeSession(responses)
+    client.retry_backoff = 0  # no real sleeping between retries
+    return client
+
+
+def _summary(**over):
+    base = {
+        "id": 42,
+        "email": "e2e+run@mailbox.test",
+        "from_email": "newsletter@example.com",
+        "subject": "Homework submission saved: E2E Homework 1",
+        "template_key": "homework-submission-confirmation",
+        "status": "sent",
+        "idempotency_key": "homework-submission:123",
+        "created_at": "2026-06-20T10:00:00Z",
+    }
+    base.update(over)
+    return base
+
+
+# -- configuration ---------------------------------------------------------
+
+
+def test_unconfigured_client_raises():
+    client = MockInboxClient(None, None)
+    assert client.configured is False
+    with pytest.raises(InboxNotConfigured):
+        client.list_messages("e2e+x@mailbox.test")
+
+
+def test_configured_requires_both_url_and_key():
+    assert MockInboxClient("https://x", None).configured is False
+    assert MockInboxClient(None, "k").configured is False
+    assert MockInboxClient("https://x", "k").configured is True
+
+
+def test_messages_url_appends_api_path():
+    client = MockInboxClient("https://datamailer.example/", "k")
+    assert client.messages_url == "https://datamailer.example/api/mock-inbox/messages"
+
+
+# -- list / auth / params --------------------------------------------------
+
+
+def test_list_messages_sends_bearer_and_params():
+    client = _client([FakeResponse(200, {"address": "a", "count": 1, "messages": [_summary()]})])
+    messages = client.list_messages("e2e+run@mailbox.test", limit=10)
+
+    method, url, kwargs = client._session.calls[0]
+    assert method == "GET"
+    assert url.endswith("/api/mock-inbox/messages")
+    assert kwargs["params"] == {"address": "e2e+run@mailbox.test", "limit": 10}
+    assert kwargs["headers"]["Authorization"] == "Bearer k-secret"
+
+    assert len(messages) == 1
+    msg = messages[0]
+    assert msg.id == 42
+    assert msg.template_key == "homework-submission-confirmation"
+    assert "E2E Homework 1" in msg.subject
+
+
+# -- detail + body/context matching ---------------------------------------
+
+
+def test_get_message_unwraps_detail_and_loads_context():
+    detail = _summary() | {
+        "html_body": "<a href='/homework/hw-1'>Update your submission</a>",
+        "text_body": "Update: https://x/homework/hw-1",
+        "context": {"update_url": "https://x/homework/hw-1", "tags": ["a"]},
+        "metadata": {"k": "v"},
+    }
+    client = _client([FakeResponse(200, {"message": detail})])
+    msg = client.get_message(42)
+    assert msg.detail_loaded
+    assert msg.context["update_url"].endswith("/homework/hw-1")
+    assert msg.body_contains("/homework/")  # found in context + body
+
+
+def test_body_contains_checks_context_values():
+    from e2e.mock_inbox import InboxMessage
+
+    msg = InboxMessage(id=1, to="x", subject="s", context={"update_url": "https://x/homework/abc"})
+    assert msg.body_contains("/homework/")
+    assert not msg.body_contains("/project/")
+
+
+# -- wait_for_message: matching, detail fetch, timeout ---------------------
+
+
+def test_wait_for_message_matches_template_and_fetches_detail():
+    list_resp = FakeResponse(200, {"messages": [_summary()]})
+    detail_resp = FakeResponse(200, {"message": _summary() | {"html_body": "<p>/homework/hw-1</p>"}})
+    client = _client([list_resp, detail_resp])
+
+    msg = client.wait_for_message(
+        "e2e+run@mailbox.test",
+        template_key="homework-submission-confirmation",
+        subject="Homework submission saved",
+        timeout=5,
+    )
+    assert msg.detail_loaded
+    assert msg.template_key == "homework-submission-confirmation"
+
+
+def test_wait_for_message_skips_non_matching_template():
+    other = _summary(template_key="welcome", subject="Welcome")
+    client = _client([FakeResponse(200, {"messages": [other]})] * 50)
+    with pytest.raises(MockInboxTimeout) as exc:
+        client.wait_for_message(
+            "e2e+run@mailbox.test",
+            template_key="homework-submission-confirmation",
+            timeout=0.2,
+            poll_interval=0.01,
+        )
+    assert "welcome" in str(exc.value)
+
+
+def test_wait_for_message_times_out_when_empty():
+    client = _client([FakeResponse(200, {"messages": []})] * 50)
+    with pytest.raises(MockInboxTimeout):
+        client.wait_for_message("e2e+run@mailbox.test", timeout=0.2, poll_interval=0.01)
+
+
+# -- disabled deployment + retries -----------------------------------------
+
+
+def test_disabled_deployment_raises_inbox_disabled():
+    disabled = FakeResponse(404, {"error": {"code": "mock_inbox_disabled"}})
+    client = _client([disabled])
+    with pytest.raises(InboxDisabled):
+        client.list_messages("e2e+run@mailbox.test")
+
+
+def test_retries_on_transport_error_then_succeeds():
+    client = _client(
+        [requests.ConnectionError("boom"), FakeResponse(200, {"messages": []})]
+    )
+    assert client.list_messages("e2e+run@mailbox.test") == []
+    assert len(client._session.calls) == 2
+
+
+def test_retries_on_5xx_then_succeeds():
+    client = _client([FakeResponse(503), FakeResponse(200, {"messages": []})])
+    assert client.list_messages("e2e+run@mailbox.test") == []
+    assert len(client._session.calls) == 2
+
+
+# -- clear -----------------------------------------------------------------
+
+
+def test_clear_sends_delete_with_address_and_returns_count():
+    client = _client([FakeResponse(200, {"address": "a", "deleted_count": 3})])
+    assert client.clear("e2e+run@mailbox.test") == 3
+    method, url, kwargs = client._session.calls[0]
+    assert method == "DELETE"
+    assert kwargs["json"] == {"address": "e2e+run@mailbox.test"}
+
+
+def test_clear_is_safe_when_unconfigured():
+    assert MockInboxClient(None, None).clear("x") == 0
+
+
+# -- real backend stub -----------------------------------------------------
+
+
+def test_real_inbox_is_unconfigured_stub():
+    real = RealInboxClient("https://x", "k")
+    assert real.configured is False
+    assert real.clear("x") == 0
+    with pytest.raises(InboxNotConfigured):
+        real.list_messages("x")
+
+
+# -- config helper ---------------------------------------------------------
+
+
+def test_mock_address_uses_tag_and_domain():
+    cfg = Settings(
+        base_url="https://x",
+        api_token=None,
+        admin_email=None,
+        admin_password=None,
+        student_email=None,
+        student_password=None,
+        mock_inbox_url=None,
+        mock_inbox_api_key=None,
+        mock_inbox_domain="mailbox.test",
+        mock_inbox_tag="e2e",
+        real_inbox_url=None,
+        real_inbox_api_key=None,
+        request_timeout=30.0,
+        ui_timeout_ms=20000,
+        expected_version=None,
+    )
+    assert cfg.mock_address("e2e-smoke-123") == "e2e+e2e-smoke-123@mailbox.test"
+    # Sanitises unexpected characters in the label.
+    assert cfg.mock_address("a b/c") == "e2e+a-b-c@mailbox.test"
+
+
+def test_load_settings_exposes_inbox_defaults():
+    cfg = load_settings()
+    assert cfg.mock_inbox_domain
+    assert cfg.mock_inbox_tag
+    # mock_address always yields a recognised mock address.
+    assert "@" in cfg.mock_address("run")

--- a/e2e/tests/test_99_teardown.py
+++ b/e2e/tests/test_99_teardown.py
@@ -3,15 +3,18 @@
 Order of operations:
 1. As the impersonated student, delete the project submission via the UI
    (the only remote way to remove a submission), then stop impersonating.
-2. Via API, close + delete every deletable homework/project, and park the
-   course (hidden) since there is no course DELETE endpoint.
-3. Post-run assertion: no *visible* ``e2e-smoke-*`` course remains.
+2. Best-effort API pre-pass on individually-deletable homeworks/projects,
+   then delete the course (and its full cascade) through the Django admin UI.
+3. Post-run assertions: the course is fully purged -- not retrievable via the
+   API and not listed among visible namespaced courses.
 
-Known platform gap: homework submissions and enrollments cannot be deleted
-by any remote caller, and courses cannot be deleted via the API. The course
-is therefore hidden rather than removed, and the "fully purged" assertion is
-xfailed with a TODO pointing at #194 (needs an admin/API delete path),
-mirroring the email-verification stub.
+Deleting the ``Course`` in the admin cascades to every related row (homeworks,
+questions, projects, submissions, answers, enrollments, peer reviews are all
+``on_delete=CASCADE``). The platform deliberately exposes **no course DELETE
+API endpoint**: a standing remote delete capability is unsafe, so cleanup goes
+through the staff-gated admin confirmation screen instead. If admin creds are
+not configured (API-only subset), teardown falls back to parking the course
+hidden and the full-purge assertion is skipped.
 """
 
 from __future__ import annotations
@@ -32,21 +35,30 @@ def test_delete_project_submission_via_ui(admin_session, run_state):
     admin_session.stop_impersonating()
 
 
-def test_teardown_deletes_provisioned_resources(provisioner, run_state):
+def test_teardown_deletes_provisioned_resources(
+    provisioner, run_state, optional_admin_session
+):
     if not run_state.course:
         pytest.skip("Nothing was provisioned.")
-    report = provisioner.teardown_course(run_state.course.slug)
+    report = provisioner.teardown_course(
+        run_state.course.slug, admin_session=optional_admin_session
+    )
     run_state.teardown_report = report
     print(
         f"[teardown] {report['course']}: "
         f"deleted={report['deleted']} residual={report['residual']}"
     )
-    # The project (submission removed via UI) should now be deletable.
-    assert any(
-        item.startswith("project:") for item in report["deleted"]
-    ) or run_state.course.project_id is None, (
-        f"Project was not deleted in teardown: {report}"
-    )
+    if optional_admin_session is not None:
+        # Admin delete should have cascaded the whole course away.
+        assert any(
+            item.startswith("course:") and "admin-deleted" in item
+            for item in report["deleted"]
+        ), f"Course was not admin-deleted in teardown: {report}"
+    else:
+        # API-only subset: no admin session, so the course is parked hidden.
+        assert any(
+            "parked hidden" in item for item in report["residual"]
+        ), f"Expected parked-hidden fallback without admin session: {report}"
 
 
 def test_no_visible_namespaced_data_remains(provisioner, run_state):
@@ -57,19 +69,22 @@ def test_no_visible_namespaced_data_remains(provisioner, run_state):
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Homework submissions, enrollments and the course shell cannot be "
-        "deleted via the API/admin, so test data cannot be fully purged "
-        "remotely. TODO(#194): add an admin/API delete path for e2e cleanup."
-    ),
-    strict=False,
-)
-def test_namespaced_course_fully_purged(provisioner, run_state):
+def test_namespaced_course_fully_purged(
+    provisioner, run_state, optional_admin_session
+):
+    """The course is actually deleted (admin cascade), not just hidden.
+
+    Only meaningful when admin creds are configured; the API-only subset parks
+    the course hidden instead, so this is skipped there.
+    """
     if not run_state.course:
         pytest.skip("Nothing was provisioned.")
-    # Will fail while the course still exists (parked + hidden) -> xfail.
+    if optional_admin_session is None:
+        pytest.skip(
+            "No admin session (E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD unset); "
+            "course is parked hidden rather than deleted."
+        )
     assert provisioner.api.get_course(run_state.namespace) is None, (
-        f"Course {run_state.namespace} still exists (parked hidden). "
+        f"Course {run_state.namespace} still exists after admin delete. "
         f"Residual: {run_state.teardown_report.get('residual')}"
     )

--- a/e2e/tests/test_99_teardown.py
+++ b/e2e/tests/test_99_teardown.py
@@ -1,0 +1,75 @@
+"""Scenario 8 (issue #194): Teardown.
+
+Order of operations:
+1. As the impersonated student, delete the project submission via the UI
+   (the only remote way to remove a submission), then stop impersonating.
+2. Via API, close + delete every deletable homework/project, and park the
+   course (hidden) since there is no course DELETE endpoint.
+3. Post-run assertion: no *visible* ``e2e-smoke-*`` course remains.
+
+Known platform gap: homework submissions and enrollments cannot be deleted
+by any remote caller, and courses cannot be deleted via the API. The course
+is therefore hidden rather than removed, and the "fully purged" assertion is
+xfailed with a TODO pointing at #194 (needs an admin/API delete path),
+mirroring the email-verification stub.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.teardown
+
+
+def test_delete_project_submission_via_ui(admin_session, run_state):
+    if not run_state.project_submitted:
+        pytest.skip("No project submission to delete.")
+    # Must still be impersonating the student here.
+    admin_session.delete_project_submission(
+        run_state.course.slug, run_state.course.project_slug
+    )
+    # Drop the impersonation so subsequent admin/API work is unambiguous.
+    admin_session.stop_impersonating()
+
+
+def test_teardown_deletes_provisioned_resources(provisioner, run_state):
+    if not run_state.course:
+        pytest.skip("Nothing was provisioned.")
+    report = provisioner.teardown_course(run_state.course.slug)
+    run_state.teardown_report = report
+    print(
+        f"[teardown] {report['course']}: "
+        f"deleted={report['deleted']} residual={report['residual']}"
+    )
+    # The project (submission removed via UI) should now be deletable.
+    assert any(
+        item.startswith("project:") for item in report["deleted"]
+    ) or run_state.course.project_id is None, (
+        f"Project was not deleted in teardown: {report}"
+    )
+
+
+def test_no_visible_namespaced_data_remains(provisioner, run_state):
+    active = provisioner.list_active_namespaced_courses()
+    assert run_state.namespace not in active, (
+        f"Course {run_state.namespace} is still visible after teardown: "
+        f"{active}"
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Homework submissions, enrollments and the course shell cannot be "
+        "deleted via the API/admin, so test data cannot be fully purged "
+        "remotely. TODO(#194): add an admin/API delete path for e2e cleanup."
+    ),
+    strict=False,
+)
+def test_namespaced_course_fully_purged(provisioner, run_state):
+    if not run_state.course:
+        pytest.skip("Nothing was provisioned.")
+    # Will fail while the course still exists (parked + hidden) -> xfail.
+    assert provisioner.api.get_course(run_state.namespace) is None, (
+        f"Course {run_state.namespace} still exists (parked hidden). "
+        f"Residual: {run_state.teardown_report.get('residual')}"
+    )


### PR DESCRIPTION
Closes part of #194. Standalone Playwright e2e smoke suite run against dev (manual + scheduled, **not** on deploy): provisions a course/homework/project, submits via UI, scores, checks leaderboard/dashboards, and tears down by deleting the test course through the Django admin UI (cascades; no DELETE endpoint added, by design).

Email verification has two pluggable backends: the Datamailer **mock-store** (default, fast) for most tests and a **real SES round-trip** for 1–2 deliverability canaries. Gated on the datamailer mock-inbox/SES branches being deployed to dev + CI secrets (see e2e/README.md).